### PR TITLE
remove dependency on TeX

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,14 +36,14 @@ jobs:
               # See https://stackoverflow.com/questions/58121461/runtimeerror-failed-to-process-string-with-tex-because-latex-could-not-be-found
               # and https://github.com/garrettj403/SciencePlots/issues/53
               sudo apt update
-              sudo apt-get install texlive-latex-extra texlive-fonts-recommended cm-super
+              # sudo apt-get install texlive-latex-extra texlive-fonts-recommended cm-super
           elif [ "$RUNNER_OS" == "macOS" ]; then
 
               # Install macports for the latex stuff. See https://github.com/GiovanniBussi/macports-ci
               curl -LO https://raw.githubusercontent.com/GiovanniBussi/macports-ci/master/macports-ci
               source ./macports-ci install
 
-              sudo port install texlive-latex-extra texlive-fonts-recommended
+              # sudo port install texlive-latex-extra texlive-fonts-recommended
           fi
 
           pip install pytest nbconvert ipykernel latex

--- a/examples/gw_eccentricity_demo.ipynb
+++ b/examples/gw_eccentricity_demo.ipynb
@@ -28,7 +28,7 @@
     "from gw_eccentricity import measure_eccentricity\n",
     "from gw_eccentricity import get_available_methods\n",
     "from gw_eccentricity.plot_settings import use_fancy_plotsettings, labelsDict\n",
-    "use_fancy_plotsettings()    # for better looking plots"
+    "use_fancy_plotsettings(usetex=False)    # for better looking plots"
    ]
   },
   {
@@ -884,7 +884,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/examples/load_waveform_demo.ipynb
+++ b/examples/load_waveform_demo.ipynb
@@ -214,7 +214,7 @@
     "}\n",
     "origin = \"LAL\"\n",
     "dataDict = load_waveform(origin, **kwargs)\n",
-    "use_fancy_plotsettings() # use better defaults for plotting\n",
+    "use_fancy_plotsettings(usetex=False) # use better defaults for plotting\n",
     "fig, ax = plt.subplots(figsize=(12, 4))\n",
     "# Plot the amplitude of the (2,2) mode\n",
     "ax.plot(dataDict[\"t\"], np.abs(dataDict[\"hlm\"][(2, 2)]), label=kwargs[\"approximant\"])\n",
@@ -371,7 +371,7 @@
     "dataDict = load_waveform(origin, **kwargs)\n",
     "\n",
     "# use better defaults for plotting\n",
-    "use_fancy_plotsettings()\n",
+    "use_fancy_plotsettings(usetex=False)\n",
     "fig, ax = plt.subplots(figsize=(12, 4))\n",
     "# plot amplitude of the (2, 2) mode of eccentric waveform\n",
     "ax.plot(dataDict[\"t\"], np.abs(dataDict[\"hlm\"][(2, 2)]), label=origin)\n",
@@ -499,7 +499,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.10.9"
   },
   "vscode": {
    "interpreter": {

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -1922,7 +1922,7 @@ class eccDefinition:
     def make_diagnostic_plots(
             self,
             add_help_text=True,
-            usetex=True,
+            usetex=False,
             style=None,
             use_fancy_settings=True,
             twocol=False,
@@ -1977,7 +1977,7 @@ class eccDefinition:
             Default is True.
         usetex:
             If True, use TeX to render texts.
-            Default is True.
+            Default is False.
         style:
             Set font size, figure size suitable for particular use case. For
             example, to generate plot for "APS" journals, use style="APS".  For
@@ -2062,7 +2062,7 @@ class eccDefinition:
             fig=None,
             ax=None,
             add_help_text=True,
-            usetex=True,
+            usetex=False,
             style="Notebook",
             use_fancy_settings=True,
             add_vline_at_tref=True,
@@ -2082,7 +2082,7 @@ class eccDefinition:
             Default is True.
         usetex:
             If True, use TeX to render texts.
-            Default is True.
+            Default is False.
         style:
             Set font size, figure size suitable for particular use case. For
             example, to generate plot for "APS" journals, use style="APS".  For
@@ -2134,7 +2134,7 @@ class eccDefinition:
             fig=None,
             ax=None,
             add_help_text=True,
-            usetex=True,
+            usetex=False,
             style="Notebook",
             use_fancy_settings=True,
             **kwargs):
@@ -2155,7 +2155,7 @@ class eccDefinition:
             Default is True.
         usetex:
             If True, use TeX to render texts.
-            Default is True.
+            Default is False.
         style:
             Set font size, figure size suitable for particular use case. For
             example, to generate plot for "APS" journals, use style="APS".  For
@@ -2207,7 +2207,7 @@ class eccDefinition:
             fig=None,
             ax=None,
             add_help_text=True,
-            usetex=True,
+            usetex=False,
             style="Notebook",
             use_fancy_settings=True,
             add_vline_at_tref=True,
@@ -2227,7 +2227,7 @@ class eccDefinition:
             Default is True.
         usetex:
             If True, use TeX to render texts.
-            Default is True.
+            Default is False.
         style:
             Set font size, figure size suitable for particular use case. For
             example, to generate plot for "APS" journals, use style="APS".  For
@@ -2279,7 +2279,7 @@ class eccDefinition:
             fig=None,
             ax=None,
             add_help_text=True,
-            usetex=True,
+            usetex=False,
             style="Notebook",
             use_fancy_settings=True,
             **kwargs):
@@ -2302,7 +2302,7 @@ class eccDefinition:
             Default is True.
         usetex:
             If True, use TeX to render texts.
-            Default is True.
+            Default is False.
         style:
             Set font size, figure size suitable for particular use case. For
             example, to generate plot for "APS" journals, use style="APS".  For
@@ -2373,7 +2373,7 @@ class eccDefinition:
             fig=None,
             ax=None,
             add_help_text=True,
-            usetex=True,
+            usetex=False,
             style="Notebook",
             use_fancy_settings=True,
             plot_omega22=True,
@@ -2394,7 +2394,7 @@ class eccDefinition:
             Default is True.
         usetex:
             If True, use TeX to render texts.
-            Default is True.
+            Default is False.
         style:
             Set font size, figure size suitable for particular use case. For
             example, to generate plot for "APS" journals, use style="APS".  For
@@ -2476,7 +2476,7 @@ class eccDefinition:
             fig=None,
             ax=None,
             add_help_text=True,
-            usetex=True,
+            usetex=False,
             style="Notebook",
             use_fancy_settings=True,
             **kwargs):
@@ -2498,7 +2498,7 @@ class eccDefinition:
             Default is True.
         usetex:
             If True, use TeX to render texts.
-            Default is True.
+            Default is False.
         style:
             Set font size, figure size suitable for particular use case. For
             example, to generate plot for "APS" journals, use style="APS".  For
@@ -2546,7 +2546,7 @@ class eccDefinition:
             fig=None,
             ax=None,
             add_help_text=True,
-            usetex=True,
+            usetex=False,
             style="Notebook",
             use_fancy_settings=True,
             **kwargs):
@@ -2571,7 +2571,7 @@ class eccDefinition:
             Default is True.
         usetex:
             If True, use TeX to render texts.
-            Default is True.
+            Default is False.
         style:
             Set font size, figure size suitable for particular use case. For
             example, to generate plot for "APS" journals, use style="APS".  For
@@ -2637,7 +2637,7 @@ class eccDefinition:
             fig=None,
             ax=None,
             add_help_text=True,
-            usetex=True,
+            usetex=False,
             style="Notebook",
             use_fancy_settings=True,
             **kwargs):
@@ -2660,7 +2660,7 @@ class eccDefinition:
             Default is True.
         usetex:
             If True, use TeX to render texts.
-            Default is True.
+            Default is False.
         style:
             Set font size, figure size suitable for particular use case. For
             example, to generate plot for "APS" journals, use style="APS".  For
@@ -2710,7 +2710,7 @@ class eccDefinition:
             fig=None,
             ax=None,
             add_help_text=True,
-            usetex=True,
+            usetex=False,
             style="Notebook",
             use_fancy_settings=True,
             **kwargs):
@@ -2729,7 +2729,7 @@ class eccDefinition:
             Default is True.
         usetex:
             If True, use TeX to render texts.
-            Default is True.
+            Default is False.
         style:
             Set font size, figure size suitable for particular use case. For
             example, to generate plot for "APS" journals, use style="APS".  For
@@ -2781,7 +2781,7 @@ class eccDefinition:
             fig=None,
             ax=None,
             add_help_text=True,
-            usetex=True,
+            usetex=False,
             style="Notebook",
             use_fancy_settings=True,
             add_vline_at_tref=True,
@@ -2802,7 +2802,7 @@ class eccDefinition:
             Default is True.
         usetex:
             If True, use TeX to render texts.
-            Default is True.
+            Default is False.
         style:
             Set font size, figure size suitable for particular use case. For
             example, to generate plot for "APS" journals, use style="APS".  For

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -2350,12 +2350,20 @@ class eccDefinition:
         ax.set_ylim(ymin - pad, ymax + pad)
         # add help text
         if add_help_text:
+            if usetex:
+                help_text = (
+                    r"\noindent To avoid extrapolation, first and last\\"
+                    r"extrema are excluded when\\"
+                    r"evaluating $\omega_{a}$/$\omega_{p}$ interpolants")
+            else:
+                help_text = (
+                    "To avoid extrapolation, first and last\n"
+                    "extrema are excluded when\n"
+                    r"evaluating $\omega_{a}$/$\omega_{p}$ interpolants")
             ax.text(
                 0.22,
                 0.98,
-                (r"\noindent To avoid extrapolation, first and last\\"
-                 r"extrema are excluded when\\"
-                 r"evaluating $\omega_{a}$/$\omega_{p}$ interpolants"),
+                help_text,
                 ha="left",
                 va="top",
                 transform=ax.transAxes)
@@ -2459,7 +2467,7 @@ class eccDefinition:
             ax.text(
                 0.35,
                 0.98,
-                (r"\noindent omega22_average should be "
+                (r"omega22_average should be "
                  "monotonically increasing."),
                 ha="left",
                 va="top",

--- a/gw_eccentricity/plot_settings.py
+++ b/gw_eccentricity/plot_settings.py
@@ -125,8 +125,9 @@ def use_fancy_plotsettings(usetex=True, style="Notebook"):
     rc("legend", frameon=False)
     rc("legend", fontsize=fontSizeDict[style])
     # Fonts
-    rc("font", family="serif")
-    rc("font", serif="times")
+    if usetex:
+        rc("font", family="serif")
+        rc("font", serif="times")
     rc("font", size=fontSizeDict[style])
     # Lines
     rc("lines", linewidth=1.0)


### PR DESCRIPTION
Plot settings were using `usetex=True` by default which requires `TeX` installation. This PR makes `usetex=False` by default and hence requires no `TeX` installation for things to work smoothly.