### PR TITLE
upgrade to v1.0.2

### DIFF
--- a/README_developers.md
+++ b/README_developers.md
@@ -26,6 +26,6 @@ Note: Currently, only Vijay and Arif can do this, as they are the only ones with
 1. Update the version number at the top of gw_eccentricity/gw_eccentricity.py and commit all changes. This version number gets propagated to setup.py.
 2. Do the following to release the new version:
 ```shell
-python setup.py sdist bdist_wheel
+python -m build
 twine upload dist/*
 ```

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -8,7 +8,7 @@ __copyright__ = "Copyright (C) 2023 Md Arif Shaikh, Vijay Varma, Harald Pfeiffer
 __email__ = "arifshaikh.astro@gmail.com, vijay.varma392@gmail.com"
 __status__ = "testing"
 __author__ = "Md Arif Shaikh, Vijay Varma, Harald Pfeiffer"
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __license__ = """
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
running `setup.py` directly is deprecated. Changed to `python -m build`.