### PR TITLE
allow Amp, omega, phase in dataDict

### DIFF
--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -443,7 +443,7 @@ class eccDefinition:
                                        dataDict,
                                        num_orbits_to_exclude_before_merger,
                                        extra_kwargs):
-        """Truncate dataDict if "num_orbits_to_exclude_before_merger" is not None.
+        """Truncate dataDict if `num_orbits_to_exclude_before_merger` is not None.
 
         parameters
         ----------
@@ -456,9 +456,14 @@ class eccDefinition:
 
         Returns
         -------
-        dataDict:
-            Truncated if num_orbits_to_exclude_before_merger is not None
-            else the unchanged dataDict.
+        newDataDict:
+            Dictionary containing the amplitude, phase and omega of the
+            eccentric waveform modes. Includes the same of the zeroecc waveform
+            modes when present in the input `dataDict`.
+
+            If `num_orbits_to_exclude_before_merger` is not None, then the
+            eccentric data, i.e., amplitude, phase, omega of the available
+            modes, are truncated before newDataDict is returned.
         t_merger:
             Merger time evaluated as the time of the global maximum of
             amplitude_using_all_modes. This is computed before the truncation.
@@ -522,14 +527,11 @@ class eccDefinition:
                     num_orbits_to_exclude_before_merger)
             # Truncate amp, phase, omega in eccentric waveform data.
             for k in ["amplm", "phaselm", "omegalm"]:
-                if k in newDataDict:
-                    for mode in newDataDict[k]:
-                        newDataDict[k][mode] \
-                            = newDataDict[k][mode][
-                                :index_num_orbits_earlier_than_merger]
-                        newDataDict["t"] \
-                            = newDataDict["t"][
-                                :index_num_orbits_earlier_than_merger]
+                for mode in newDataDict[k]:
+                    newDataDict[k][mode] = newDataDict[k][mode][
+                        :index_num_orbits_earlier_than_merger]
+                    newDataDict["t"] = newDataDict["t"][
+                        :index_num_orbits_earlier_than_merger]
         return newDataDict, t_merger, amp22_merger, min_width_for_extrema
 
     def get_width_for_peak_finder_from_phase22(self,

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -44,11 +44,13 @@ class eccDefinition:
                         "omegalm_zeroecc": omegaDict,
                        }
 
-            "t" and at least one of the followings are mandatory:
+            "t" and one of the followings are mandatory:
 
             - "hlm"
             - "amplm" and "phaselm"
 
+            Note that providing "hlm", "amplm" and "phaselm" all at the same
+            time will raise error.
             Apart from specifying "hlm" or "amplm" and "phaselm", the user can
             also provide "omegalm". If the "omegalm" key is not explicitly
             provided, it is computed from the given "hlm" or "phaselm" using
@@ -56,11 +58,13 @@ class eccDefinition:
 
             The keys with suffix "zeroecc" are only required for
             `ResidualAmplitude` and `ResidualFrequency` methods, where
-            "t_zeroecc" and at least one of the followings are to be provided:
+            "t_zeroecc" and one of the followings are to be provided:
 
             - "hlm_zeroecc"
             - "amplm_zeroecc" and "phaselm_zeroecc"
 
+            Note that providing "hlm_zeroecc", "amplm_zeroecc" and
+            "phaselm_zeroecc" all at the same time will raise error.
             Similar to "omegalm", the user can also provide "omegalm_zeroecc".
             If it is not provided in `dataDict`, it is computed from the given
             "hlm_zeroecc" or "phaselm_zeroecc" using finite difference method.
@@ -506,6 +510,15 @@ class eccDefinition:
             Minimum width for the `find_peaks` function. This is computed
             before the truncation.
         """
+        # Check that the dataDict contains either the hlms or the amplm/phaselm
+        # and not both of these.
+        for suffix in ["", "_zeroecc"]:
+            if all(key+suffix in dataDict for key in
+                   ["hlm", "amplm", "phaselm"]):
+                raise Exception(
+                    f"Provide either `hlm{suffix}` or both of `amplm{suffix}` "
+                    f"and `phaselm{suffix}`. `dataDict` should not contain "
+                    "all of the three at the same time.")
         # Create a new dictionary that will contain the data necessary for
         # eccentricity measurement.
         newDataDict = {}

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -35,12 +35,28 @@ class eccDefinition:
             the format:
             dataDict = {"t": time,
                         "hlm": modeDict,
+                        "amplm": ampDict,
+                        "phaselm": phaseDict,
+                        "omegalm": omegaDict,
                         "t_zeroecc": time,
                         "hlm_zeroecc": modeDict,
+                        "amplm_zeroecc": ampDict,
+                        "phaselm_zeroecc": phaseDict,
+                        "omegalm_zeroecc": omegaDict,
                        },
-            "t" and "hlm" are mandatory. "t_zeroecc" and "hlm_zeroecc"
+            "t" and at least one of the followings are mandatory:
+            - "hlm"
+            - "amplm" and "phaselm"
+            - "amplm" and "omegalm".
+
+            The keys with suffix "zeroecc"
             are only required for `ResidualAmplitude` and
-            `ResidualFrequency` methods, but if provided, they are
+            `ResidualFrequency` methods, where "t_zeroecc" and
+            at least one of the followings are to be provided:
+            - "hlm_zeroecc"
+            - "amplm_zeroecc" and "phaselm_zeroecc"
+            - "amplm_zeroecc" and "omegalm_zeroecc".
+            If provided for other methods, they are
             used for additional diagnostic plots, which can be helpful
             for all methods. Any other keys in dataDict will be
             ignored, with a warning.
@@ -68,6 +84,12 @@ class eccDefinition:
                     m) waveform mode. Should contain at least the (2, 2) mode,
                     but more modes can be included, as indicated by the
                     ellipsis '...'  above.
+            - "amplm": Dictionary of amplitudes of waveform modes associated
+              with "t". Should have the same format as "hlm".
+            - "phaselm": Dictionary of phases of waveform modes associated
+              with "t". Should have the same format as "hlm".
+            - "omegalm": Dictionary of the frequencies of the waveform modes
+              associated with "t". Should have the same format as "hlm".
             - "t_zeroecc" and "hlm_zeroecc":
                 - Same as above, but for the quasicircular counterpart to the
                   eccentric waveform. The quasicircular counterpart can be
@@ -83,6 +105,10 @@ class eccDefinition:
                   peak time does not have to match that of "t".
                 - We require that "hlm_zeroecc" be at least as long as "hlm" so
                   that residual amplitude/frequency can be computed.
+            - "amplm_zeroecc", "phaselm_zeroecc" and "omegalm_zeroecc":
+                Same as "amplm", "phaselm" and "omegalm", respectively, but
+                for the quasicircular counterpart to the eccentric waveform.
+                Should have same format as "hlm_zeroecc".
 
         num_orbits_to_exclude_before_merger:
                 Can be None or a non negative number.  If None, the full

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -95,13 +95,20 @@ class eccDefinition:
                     ellipsis '...'  above.
 
             - "amplm": Dictionary of amplitudes of waveform modes associated
-              with "t". Should have the same format as "hlm".
+              with "t". Should have the same format as "hlm", except that the
+              amplitude is real.
 
             - "phaselm": Dictionary of phases of waveform modes associated
-              with "t". Should have the same format as "hlm".
+              with "t". Should have the same format as "hlm", except that the
+              phase is real. The phaselm is related to hlm as hlm = amplm *
+              exp(- i phaselm) ensuring that the phaselm is monotonically
+              increasing.
 
             - "omegalm": Dictionary of the frequencies of the waveform modes
-              associated with "t". Should have the same format as "hlm".
+              associated with "t". Should have the same format as "hlm", except
+              that the omegalm is real. omegalm is obtained from the phaselm
+              (see above) as omegalm = d/dt phaselm, which means that the
+              omegalm is positive.
 
             - "t_zeroecc" and "hlm_zeroecc":
 

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -44,13 +44,12 @@ class eccDefinition:
                         "omegalm_zeroecc": omegaDict,
                        }
 
-            "t" and one of the followings are mandatory:
+            "t" and one of the following is mandatory:
 
-            - "hlm"
-            - "amplm" and "phaselm"
+            1. "hlm" OR
+            2. "amplm" and "phaselm"
+                but not both 1 and 2 at the same time.
 
-            Note that providing "hlm" and "amplm" or "phaselm" at the same
-            time will raise error.
             Apart from specifying "hlm" or "amplm" and "phaselm", the user can
             also provide "omegalm". If the "omegalm" key is not explicitly
             provided, it is computed from the given "hlm" or "phaselm" using
@@ -58,13 +57,12 @@ class eccDefinition:
 
             The keys with suffix "zeroecc" are only required for
             `ResidualAmplitude` and `ResidualFrequency` methods, where
-            "t_zeroecc" and one of the followings are to be provided:
+            "t_zeroecc" and one of the following is to be provided:
 
-            - "hlm_zeroecc"
-            - "amplm_zeroecc" and "phaselm_zeroecc"
+            1. "hlm_zeroecc" OR
+            2. "amplm_zeroecc" and "phaselm_zeroecc"
+               but not both 1 and 2 at the same time.
 
-            Note that providing "hlm_zeroecc" and "amplm_zeroecc" or
-            "phaselm_zeroecc" at the same time will raise error.
             Similar to "omegalm", the user can also provide "omegalm_zeroecc".
             If it is not provided in `dataDict`, it is computed from the given
             "hlm_zeroecc" or "phaselm_zeroecc" using finite difference method.
@@ -401,9 +399,9 @@ class eccDefinition:
                 for k in dataDict["hlm" + suffix]:
                     ampDict.update({k: np.abs(dataDict["hlm" + suffix][k])})
             elif suffix == "":
-                raise Exception("dataDict should contain at least one of "
-                                "['amplm' 'hlm'] for computing amplitude of "
-                                "the waveform modes.")
+                raise Exception("`dataDict` should contain either 'amplm' or "
+                                " 'hlm' for computing amplitude of the "
+                                "waveform modes.")
         amplmDict = {"amplm": amplm}
         if amplm_zeroecc:
             amplmDict.update({"amplm_zeroecc": amplm_zeroecc})
@@ -429,9 +427,9 @@ class eccDefinition:
                         {k: - np.unwrap(
                             np.angle(dataDict["hlm" + suffix][k]))})
             elif suffix == "":
-                raise Exception("dataDict should contain at least one of "
-                                "['phaselm', 'hlm'] for computing phase of "
-                                "the waveform modes.")
+                raise Exception("`dataDict` should contain either 'phaselm' "
+                                "or 'hlm' for computing phase of the waveform "
+                                "modes.")
         phaselmDict = {"phaselm": phaselm}
         if phaselm_zeroecc:
             phaselmDict.update({"phaselm_zeroecc": phaselm_zeroecc})

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -508,16 +508,28 @@ class eccDefinition:
             Minimum width for the `find_peaks` function. This is computed
             before the truncation.
         """
-        # Check that the dataDict contains either the hlms or the amplm/phaselm
-        # and not both of these.
+        # Raise exception if hlm is provided and amplm and/or phaselm is also
+        # provided. It tests that exactly one of either hlm or (amplm and
+        # phaselm) is provided.
         for suffix in ["", "_zeroecc"]:
-            if "hlm"+suffix in dataDict and ("amplm"+suffix in dataDict
-                                             or "phaselm"+suffix in dataDict):
+            if ("hlm"+suffix in dataDict) and any(
+                    ["amplm"+suffix in dataDict,
+                     "phaselm"+suffix in dataDict]):
                 raise Exception(
-                    f"Provide either `hlm{suffix}` or both of `amplm{suffix}` "
-                    f"and `phaselm{suffix}`. `dataDict` should not contain "
-                    f"`hlm{suffix}` and `amplm{suffix}` or `phaselm{suffix}` "
-                    "at the same time.")
+                    f"`dataDict` {'should' if suffix == '' else 'may'} "
+                    "contain one of the following: \n"
+                    f"1. 'hlm{suffix}' OR \n"
+                    f"2. 'amplm{suffix}' and 'phaselm{suffix}'\n"
+                    "But not both 1. and 2. at the same time.")
+        # Raise exception if hlm is not provided but either amplm and/or
+        # phaselm is also not provided
+        if ("hlm" not in dataDict) and any(["amplm" not in dataDict,
+                                            "phaselm" not in dataDict]):
+            raise Exception((
+                "`dataDict` should contain one of the following: \n"
+                "1. 'hlm' OR \n"
+                "2. 'amplm' and 'phaselm'\n"
+                "But not both 1. and 2. at the same time."))
         # Create a new dictionary that will contain the data necessary for
         # eccentricity measurement.
         newDataDict = {}

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -520,17 +520,17 @@ class eccDefinition:
                     phase22,
                     phase22_merger,
                     num_orbits_to_exclude_before_merger)
-            dataDict = copy.deepcopy(newDataDict)
+            # Truncate amp, phase, omega in eccentric waveform data.
             for k in ["amplm", "phaselm", "omegalm"]:
-                if k in dataDict:
-                    for mode in dataDict[k]:
-                        dataDict[k][mode] \
-                            = dataDict[k][mode][
+                if k in newDataDict:
+                    for mode in newDataDict[k]:
+                        newDataDict[k][mode] \
+                            = newDataDict[k][mode][
                                 :index_num_orbits_earlier_than_merger]
-                        dataDict["t"] \
-                            = dataDict["t"][
+                        newDataDict["t"] \
+                            = newDataDict["t"][
                                 :index_num_orbits_earlier_than_merger]
-        return dataDict, t_merger, amp22_merger, min_width_for_extrema
+        return newDataDict, t_merger, amp22_merger, min_width_for_extrema
 
     def get_width_for_peak_finder_from_phase22(self,
                                                t,

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -315,20 +315,30 @@ class eccDefinition:
         return list_of_keys
 
     def get_amp_phase_omega_data(self, dataDict):
-        """Get the dictionary of amplitude, omega and phase from user dataDict.
+        """
+        Extract the dictionary of amplitude, omega, and phase from `dataDict`.
 
         The `dataDict` provided by the user can contain any of the data
         corresponding to the keys in `get_recognized_dataDict_keys`. To compute
-        eccentricity and mean anomaly, we need amplitude, phase and omega. In
-        this function, we get these data from `dataDict` and create a new
-        dictionary that contains only the amplitude, phase and omega of the
+        eccentricity and mean anomaly, we need amplitude, phase, and
+        omega. This function extracts these data from `dataDict` and creates a
+        new dictionary containing only the amplitude, phase, and omega of the
         available modes.
 
-        For example, if `dataDict` has only the complex hlm modes, this
-        functions uses the hlm modes to create a dictionary containing the
-        amplitude, phase and omega by decomposing the hlm modes. Afterwards,
-        only these waveform data in the new dataDict is used for all
+        For example, if `dataDict` contains only the complex hlm modes, this
+        function uses the hlm modes to create a new dictionary containing the
+        amplitude, phase, and omega by decomposing the hlm modes.  Afterwards,
+        only these waveform data in the new dataDict will be used for all
         further computations.
+
+        Parameters:
+            dataDict: dict
+                A dictionary containing waveform data.
+
+        Returns:
+            amp_phase_omega_dict: dict
+                A new dictionary containing only the amplitude, phase, and
+                omega dict of available modes.
         """
         amp_phase_omega_dict = {}
         # add amplm and amplm_zeroecc if zeroecc data provided
@@ -427,60 +437,60 @@ class eccDefinition:
                           extra_kwargs):
         """Get necessary data for eccentricity measurement from `dataDict`.
 
-        To measure the eccentricity we need a few different data which
-        includes:
+        To measure the eccentricity, several waveform data are required,
+        including:
 
-        - amplitude: To locate the merger time from its global maxima. It may
-          also be used to locate the pericenters/apocenters depending on the
-          method.
-        - phase: To estimate the time at a given number of orbits before the
-          merger
-        - omega: To compute the frequency at the pericenters/apocenters which
-          are required to build the interpolant through the
-          pericenters/apocenters. It may also be used to find the
+        - amplitude: Used to locate the merger time from its global maxima and
+          may also be utilized to find the pericenters/apocenters depending on
+          the method.
+        - phase: Helps estimate the time at a given number of orbits before the
+          merger.
+        - omega: Required to compute the frequency at the
+          pericenters/apocenters, which are essential for building the
+          interpolant through them. It may also be used to find the
           pericenters/apocenters depending on the method.
 
-        These are also used to make different checks and diagnostic plots, for
-        example.
+        These waveform data are also used for various checks and diagnostic
+        plots.
 
-        The user-provided `dataDict` may contain any of the data mentioned in
-        `get_recognized_dataDict_keys`. From `dataDict`, amplitude, phase and
-        omega data are obtained. If `num_orbits_to_exclude_before_merger` is
-        not None, then these data (but only corresponding to the eccentric
-        waveform) are truncated before returning.
+        The `dataDict` provided by the user may contain any of the data
+        mentioned in `get_recognized_dataDict_keys`. From `dataDict`, the
+        amplitude, phase, and omega data are obtained. If
+        `num_orbits_to_exclude_before_merger` is not None, then these data
+        (corresponding to the eccentric waveform) are truncated before
+        returning.
 
         In addition to the above data, this function returns a few more
-        variables -- `t_merger`, `amp22_merger` and `min_width_for_extrema` for
-        future usage. See the docs below for more details.
+        variables -- `t_merger`, `amp22_merger`, and `min_width_for_extrema`
+        for future usage. See the details below.
 
-        parameters
-        ----------
-        dataDict:
-            Dictionary containing modes and times.
-        num_orbits_to_exclude_before_merger: Number of orbits to exclude before
-            merger to get the truncated dataDict.
-        extra_kwargs:
-            Extra kwargs passed to the measure eccentricity.
+        Parameters:
+            dataDict: dict
+                Dictionary containing modes and times.
+            num_orbits_to_exclude_before_merger: int or None
+                Number of orbits to exclude before the merger to get the
+                truncated dataDict. If None, no truncation is performed.
+            extra_kwargs:
+                Extra keyword arguments passed to the measure eccentricity.
 
-        Returns
-        -------
-        newDataDict:
-            Dictionary containing the amplitude, phase and omega of the
-            eccentric waveform modes. Includes the same of the zeroecc waveform
-            modes when present in the input `dataDict`.
-
-            If `num_orbits_to_exclude_before_merger` is not None, then the
-            eccentric data, i.e., amplitude, phase, omega of the available
-            modes, are truncated before newDataDict is returned.
-        t_merger:
-            Merger time evaluated as the time of the global maximum of
-            amplitude_using_all_modes. This is computed before the truncation.
-        amp22_merger:
-            Amplitude of the (2, 2) mode at t_merger. This is computed before
-            the truncation.
-        min_width_for_extrema:
-            Minimum width for find_peaks function. This is computed before the
-            truncation.
+        Returns:
+            newDataDict: dict
+                Dictionary containing the amplitude, phase, and omega of the
+                eccentric waveform modes. Includes the same of the zeroecc
+                waveform modes when present in the input `dataDict`. If
+                `num_orbits_to_exclude_before_merger` is not None, then the
+                eccentric data, i.e., amplitude, phase, and omega of the
+                available modes, are truncated before newDataDict is returned.
+            t_merger: float
+                Merger time evaluated as the time of the global maximum of
+                `amplitude_using_all_modes`. This is computed before the
+                truncation.
+            amp22_merger: float
+                Amplitude of the (2, 2) mode at t_merger. This is computed
+                before the truncation.
+            min_width_for_extrema: float
+                Minimum width for the `find_peaks` function. This is computed
+                before the truncation.
         """
         # Create a new dictionary that will contain the data necessary for
         # eccentricity measurement.

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -7,7 +7,6 @@ https://github.com/vijayvarma392/gw_eccentricity/wiki/Adding-new-eccentricity-de
 """
 
 import numpy as np
-from scipy import integrate
 from .utils import peak_time_via_quadratic_fit, check_kwargs_and_set_defaults
 from .utils import amplitude_using_all_modes
 from .utils import time_deriv_4thOrder
@@ -50,17 +49,28 @@ class eccDefinition:
             - "hlm"
             - "amplm" and "phaselm"
 
-            The keys with suffix "zeroecc"
-            are only required for `ResidualAmplitude` and
-            `ResidualFrequency` methods, where "t_zeroecc" and
-            at least one of the followings are to be provided:
+            Apart from specifying "hlm" or "amplm" and "phaselm", the user can
+            also provide "omegalm". If the "omegalm" key is not explicitly
+            provided, it is computed from the given "hlm" or "phaselm" using
+            finite difference method.
+
+            The keys with suffix "zeroecc" are only required for
+            `ResidualAmplitude` and `ResidualFrequency` methods, where
+            "t_zeroecc" and at least one of the followings are to be provided:
 
             - "hlm_zeroecc"
             - "amplm_zeroecc" and "phaselm_zeroecc"
 
-            If provided for other methods, they are
-            used for additional diagnostic plots, which can be helpful
-            for all methods. Any other keys in dataDict will be
+            Similar to "omegalm", the user can also provide "omegalm_zeroecc".
+            If it is not provided in `dataDict`, it is computed from the given
+            "hlm_zeroecc" or "phaselm_zeroecc" using finite difference method.
+
+            If zeroecc data are provided for methods other than
+            `ResidualAmplitude` and `ResidualFrequency`, they are used for
+            additional diagnostic plots, which can be helpful for all
+            methods.
+
+            Any keys in `dataDict` other than the recognized ones will be
             ignored, with a warning.
 
             The recognized keys are:
@@ -103,7 +113,7 @@ class eccDefinition:
 
             - "omegalm": Dictionary of the frequencies of the waveform modes
               associated with "t". Should have the same format as "hlm", except
-              that the omegalm is real. omegalm is obtained from the phaselm
+              that the omegalm is real. omegalm is related to the phaselm
               (see above) as omegalm = d/dt phaselm, which means that the
               omegalm is positive for m > 0 modes.
 
@@ -331,14 +341,16 @@ class eccDefinition:
         only these waveform data in the new dataDict will be used for all
         further computations.
 
-        Parameters:
-            dataDict: dict
-                A dictionary containing waveform data.
+        Parameters
+        ----------
+        dataDict : dict
+            A dictionary containing waveform data.
 
-        Returns:
-            amp_phase_omega_dict: dict
-                A new dictionary containing only the amplitude, phase, and
-                omega dict of available modes.
+        Returns
+        -------
+        amp_phase_omega_dict : dict
+            A new dictionary containing only the amplitude, phase, and omega
+            dict of available modes.
         """
         amp_phase_omega_dict = {}
         # add amplm and amplm_zeroecc if zeroecc data provided
@@ -464,33 +476,35 @@ class eccDefinition:
         variables -- `t_merger`, `amp22_merger`, and `min_width_for_extrema`
         for future usage. See the details below.
 
-        Parameters:
-            dataDict: dict
-                Dictionary containing modes and times.
-            num_orbits_to_exclude_before_merger: int or None
-                Number of orbits to exclude before the merger to get the
-                truncated dataDict. If None, no truncation is performed.
-            extra_kwargs:
-                Extra keyword arguments passed to the measure eccentricity.
+        Parameters
+        ----------
+        dataDict : dict
+            Dictionary containing modes and times.
+        num_orbits_to_exclude_before_merger : int or None
+            Number of orbits to exclude before the merger to get the truncated
+            dataDict. If None, no truncation is performed.
+        extra_kwargs:
+            Extra keyword arguments passed to the measure eccentricity.
 
-        Returns:
-            newDataDict: dict
-                Dictionary containing the amplitude, phase, and omega of the
-                eccentric waveform modes. Includes the same of the zeroecc
-                waveform modes when present in the input `dataDict`. If
-                `num_orbits_to_exclude_before_merger` is not None, then the
-                eccentric data, i.e., amplitude, phase, and omega of the
-                available modes, are truncated before newDataDict is returned.
-            t_merger: float
-                Merger time evaluated as the time of the global maximum of
-                `amplitude_using_all_modes`. This is computed before the
-                truncation.
-            amp22_merger: float
-                Amplitude of the (2, 2) mode at t_merger. This is computed
-                before the truncation.
-            min_width_for_extrema: float
-                Minimum width for the `find_peaks` function. This is computed
-                before the truncation.
+        Returns
+        -------
+        newDataDict : dict
+            Dictionary containing the amplitude, phase, and omega of the
+            eccentric waveform modes. Includes the same of the zeroecc waveform
+            modes when present in the input `dataDict`. If
+            `num_orbits_to_exclude_before_merger` is not None, then the
+            eccentric data, i.e., amplitude, phase, and omega of the available
+            modes, are truncated before newDataDict is returned.
+        t_merger : float
+            Merger time evaluated as the time of the global maximum of
+            `amplitude_using_all_modes`. This is computed before the
+            truncation.
+        amp22_merger : float
+            Amplitude of the (2, 2) mode at t_merger. This is computed before
+            the truncation.
+        min_width_for_extrema : float
+            Minimum width for the `find_peaks` function. This is computed
+            before the truncation.
         """
         # Create a new dictionary that will contain the data necessary for
         # eccentricity measurement.

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -49,7 +49,7 @@ class eccDefinition:
             - "hlm"
             - "amplm" and "phaselm"
 
-            Note that providing "hlm", "amplm" and "phaselm" all at the same
+            Note that providing "hlm" and "amplm" or "phaselm" at the same
             time will raise error.
             Apart from specifying "hlm" or "amplm" and "phaselm", the user can
             also provide "omegalm". If the "omegalm" key is not explicitly
@@ -63,8 +63,8 @@ class eccDefinition:
             - "hlm_zeroecc"
             - "amplm_zeroecc" and "phaselm_zeroecc"
 
-            Note that providing "hlm_zeroecc", "amplm_zeroecc" and
-            "phaselm_zeroecc" all at the same time will raise error.
+            Note that providing "hlm_zeroecc" and "amplm_zeroecc" or
+            "phaselm_zeroecc" at the same time will raise error.
             Similar to "omegalm", the user can also provide "omegalm_zeroecc".
             If it is not provided in `dataDict`, it is computed from the given
             "hlm_zeroecc" or "phaselm_zeroecc" using finite difference method.
@@ -513,12 +513,13 @@ class eccDefinition:
         # Check that the dataDict contains either the hlms or the amplm/phaselm
         # and not both of these.
         for suffix in ["", "_zeroecc"]:
-            if all(key+suffix in dataDict for key in
-                   ["hlm", "amplm", "phaselm"]):
+            if "hlm"+suffix in dataDict and ("amplm"+suffix in dataDict
+                                             or "phaselm"+suffix in dataDict):
                 raise Exception(
                     f"Provide either `hlm{suffix}` or both of `amplm{suffix}` "
                     f"and `phaselm{suffix}`. `dataDict` should not contain "
-                    "all of the three at the same time.")
+                    f"`hlm{suffix}` and `amplm{suffix}` or `phaselm{suffix}` "
+                    "at the same time.")
         # Create a new dictionary that will contain the data necessary for
         # eccentricity measurement.
         newDataDict = {}

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -331,7 +331,8 @@ class eccDefinition:
         For example, if `dataDict` has only the complex hlm modes, this
         functions uses the hlm modes to create a dictionary containing the
         amplitude, phase and omega by decomposing the hlm modes. Afterwards,
-        only this new dataDict is used for all the further computations.
+        only these waveform data in the new dataDict is used for all the
+        further computations.
         """
         amp_phase_omega_dict = {}
         # add amplm
@@ -373,10 +374,10 @@ class eccDefinition:
         amplm_zeroecc = {}
         for suffix, ampDict in zip(["", "_zeroecc"], [amplm, amplm_zeroecc]):
             if "amplm" + suffix in dataDict:
-                # Add the amplitude dictionary from dataDict to amplm
+                # Add the amplitude dictionary from dataDict to ampDict
                 ampDict.update(dataDict["amplm" + suffix])
             elif "hlm" + suffix in dataDict:
-                # compute amplitude of each hlm mode and add to amplm
+                # compute amplitude of each hlm mode and add to ampDict
                 for k in dataDict["hlm" + suffix]:
                     ampDict.update({k: np.abs(dataDict["hlm" + suffix][k])})
             else:
@@ -402,15 +403,16 @@ class eccDefinition:
         for suffix, phaseDict in zip(["", "_zeroecc"],
                                      [phaselm, phaselm_zeroecc]):
             if "phaselm" + suffix in dataDict:
-                # Add the phase dictionary from dataDict to phaselm
+                # Add the phase dictionary from dataDict to phaseDict
                 phaseDict.update(dataDict["phaselm" + suffix])
             elif "hlm" + suffix in dataDict:
                 # Compute phase of each mode in hlm and add to phaselm
                 for k in dataDict["hlm" + suffix]:
                     phaseDict.update(
-                        {k: - np.unwrap(np.angle(dataDict["hlm" + suffix][k]))})
+                        {k: - np.unwrap(
+                            np.angle(dataDict["hlm" + suffix][k]))})
             elif "omegalm" + suffix in dataDict:
-                # Compute phase of each mode from omega and add to phaselm
+                # Compute phase of each mode from omega and add to phaseDict
                 for k in dataDict["omegalm" + suffix]:
                     phaseDict.update(
                         {k: integrate.cumtrapz(

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -484,10 +484,8 @@ class eccDefinition:
         # to newDataDict
         newDataDict.update(self.get_amp_phase_omega_data(dataDict))
 
-        # Now compute data using newDataDict and then truncate it if required
-        t = newDataDict["t"]
-        # Get phase of the 22 mode.
-        phase22 = newDataDict["phaselm"][(2, 2)]
+        # Now we compute data using newDataDict and then truncate it if
+        # required.
         # We need to know the merger time of eccentric waveform.
         # This is useful, for example, to subtract the quasi circular
         # amplitude from eccentric amplitude in residual amplitude method
@@ -495,17 +493,18 @@ class eccDefinition:
         # to compute location at certain number orbits earlier than merger
         # and to rescale amp22 by it's value at the merger (in AmplitudeFits)
         # respectively.
-        amplm = newDataDict["amplm"]  # amplitude dictionary
-        amp22 = amplm[(2, 2)]
-        amp = amplitude_using_all_modes(amplm, "amplm")  # total amplitude
         t_merger = peak_time_via_quadratic_fit(
-            t, amp)[0]
-        merger_idx = np.argmin(np.abs(t - t_merger))
-        amp22_merger = amp22[merger_idx]
+            newDataDict["t"],
+            amplitude_using_all_modes(newDataDict["amplm"], "amplm"))[0]
+        merger_idx = np.argmin(np.abs(newDataDict["t"] - t_merger))
+        amp22_merger = newDataDict["amplm"][(2, 2)][merger_idx]
+        phase22 = newDataDict["phaselm"][(2, 2)]
         phase22_merger = phase22[merger_idx]
         # Minimum width for peak finding function
         min_width_for_extrema = self.get_width_for_peak_finder_from_phase22(
-            t, phase22, phase22_merger)
+            newDataDict["t"],
+            phase22,
+            phase22_merger)
         if num_orbits_to_exclude_before_merger is not None:
             # Truncate the last num_orbits_to_exclude_before_merger number of
             # orbits before merger.
@@ -518,7 +517,8 @@ class eccDefinition:
                     " Given value was {num_orbits}")
             index_num_orbits_earlier_than_merger \
                 = self.get_index_at_num_orbits_earlier_than_merger(
-                    phase22, phase22_merger,
+                    phase22,
+                    phase22_merger,
                     num_orbits_to_exclude_before_merger)
             dataDict = copy.deepcopy(newDataDict)
             for k in ["amplm", "phaselm", "omegalm"]:

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -508,9 +508,10 @@ class eccDefinition:
             Minimum width for the `find_peaks` function. This is computed
             before the truncation.
         """
+        # Test that exactly one of either hlm or (amplm and phaselm) is
+        # provided.
         # Raise exception if hlm is provided and amplm and/or phaselm is also
-        # provided. It tests that exactly one of either hlm or (amplm and
-        # phaselm) is provided.
+        # provided.
         for suffix in ["", "_zeroecc"]:
             if ("hlm"+suffix in dataDict) and any(
                     ["amplm"+suffix in dataDict,

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -335,9 +335,9 @@ class eccDefinition:
         further computations.
         """
         amp_phase_omega_dict = {}
-        # add amplm
+        # add amplm and amplm_zeroecc if zeroecc data provided
         amp_phase_omega_dict.update(self.get_amplm_from_dataDict(dataDict))
-        # add phaselm
+        # add phaselm and phaselm_zeroecc if zeroecc data provided
         amp_phase_omega_dict.update(self.get_phaselm_from_dataDict(dataDict))
         # add omegalm
         if "omegalm" in dataDict:
@@ -349,7 +349,7 @@ class eccDefinition:
                     dataDict["t"],
                     amp_phase_omega_dict["phaselm"])})
 
-        # add zeroecc omega
+        # add omegalm_zeroecc if zeroecc data is provided
         if "omegalm_zeroecc" in dataDict:
             amp_phase_omega_dict.update(
                 {"omegalm_zeroecc": dataDict["omegalm_zeroecc"]})

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -32,7 +32,8 @@ class eccDefinition:
         ---------
         dataDict: dict
             Dictionary containing waveform modes dict, time etc. Should follow
-            the format:
+            the format::
+
             dataDict = {"t": time,
                         "hlm": modeDict,
                         "amplm": ampDict,
@@ -43,8 +44,10 @@ class eccDefinition:
                         "amplm_zeroecc": ampDict,
                         "phaselm_zeroecc": phaseDict,
                         "omegalm_zeroecc": omegaDict,
-                       },
+                       }
+
             "t" and at least one of the followings are mandatory:
+
             - "hlm"
             - "amplm" and "phaselm"
             - "amplm" and "omegalm".
@@ -53,16 +56,20 @@ class eccDefinition:
             are only required for `ResidualAmplitude` and
             `ResidualFrequency` methods, where "t_zeroecc" and
             at least one of the followings are to be provided:
+
             - "hlm_zeroecc"
             - "amplm_zeroecc" and "phaselm_zeroecc"
             - "amplm_zeroecc" and "omegalm_zeroecc".
+
             If provided for other methods, they are
             used for additional diagnostic plots, which can be helpful
             for all methods. Any other keys in dataDict will be
             ignored, with a warning.
 
             The recognized keys are:
+
             - "t": 1d array of times.
+
                 - Should be uniformly sampled, with a small enough time step
                   so that omega22(t) can be accurately computed. We use a
                   4th-order finite difference scheme. In dimensionless units,
@@ -74,8 +81,10 @@ class eccDefinition:
                 - We do not require the waveform peak amplitude to occur at any
                   specific time, but tref_in should follow the same convention
                   for peak time as "t".
+
             - "hlm": Dictionary of waveform modes associated with "t".
-                - Should have the format:
+                Should have the format::
+
                     modeDict = {(l1, m1): h_{l1, m1},
                                 (l2, m2): h_{l2, m2},
                                 ...
@@ -84,13 +93,18 @@ class eccDefinition:
                     m) waveform mode. Should contain at least the (2, 2) mode,
                     but more modes can be included, as indicated by the
                     ellipsis '...'  above.
+
             - "amplm": Dictionary of amplitudes of waveform modes associated
               with "t". Should have the same format as "hlm".
+
             - "phaselm": Dictionary of phases of waveform modes associated
               with "t". Should have the same format as "hlm".
+
             - "omegalm": Dictionary of the frequencies of the waveform modes
               associated with "t". Should have the same format as "hlm".
+
             - "t_zeroecc" and "hlm_zeroecc":
+
                 - Same as above, but for the quasicircular counterpart to the
                   eccentric waveform. The quasicircular counterpart can be
                   obtained by evaluating a waveform model by keeping the rest
@@ -105,6 +119,7 @@ class eccDefinition:
                   peak time does not have to match that of "t".
                 - We require that "hlm_zeroecc" be at least as long as "hlm" so
                   that residual amplitude/frequency can be computed.
+
             - "amplm_zeroecc", "phaselm_zeroecc" and "omegalm_zeroecc":
                 Same as "amplm", "phaselm" and "omegalm", respectively, but
                 for the quasicircular counterpart to the eccentric waveform.

--- a/gw_eccentricity/eccDefinitionUsingResidualAmplitude.py
+++ b/gw_eccentricity/eccDefinitionUsingResidualAmplitude.py
@@ -40,10 +40,18 @@ class eccDefinitionUsingResidualAmplitude(eccDefinitionUsingAmplitude):
         For more details on the format of the dataDict, see documentation
         of gw_eccentricity.measure_eccentricity.
         """
-        for k in ["t_zeroecc", "hlm_zeroecc"]:
+        # suggest what data to provide when zeroecc amplitude/omega is missing
+        # for Residual methods
+        suggested_keys = {
+            "t_zeroecc": ["t_zeroecc"],
+            "amplm_zeroecc": ["amplm_zeroecc", "hlm_zeroecc"],
+            "omegalm_zeroecc": ["omegalm_zeroecc", "hlm_zeroecc", "phaselm_zeroecc"]}
+        for k in suggested_keys:
             if k not in self.dataDict:
                 raise Exception(f"Method {method} must have zeroecc data in "
-                                f"dataDict. {k} data not found.")
+                                f"dataDict. {k} data not found. "
+                                "At least one of the following data should be "
+                                f"provided: {suggested_keys[k]}")
 
     def get_data_for_finding_extrema(self):
         """Get the data for extrema finding."""

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -168,11 +168,13 @@ def measure_eccentricity(tref_in=None,
                         "omegalm_zeroecc": omegaDict,
                       }
 
-        "t" and at least one of the followings are mandatory:
+        "t" and one of the followings are mandatory:
 
         - "hlm"
         - "amplm" and "phaselm".
 
+        Note that providing "hlm", "amplm" and "phaselm" all at the same time
+        will raise error.
         Apart from specifying "hlm" or "amplm" and "phaselm", the user can also
         provide "omegalm". If the "omegalm" key is not explicitly provided, it
         is computed from the given "hlm" or "phaselm" using finite difference
@@ -180,11 +182,13 @@ def measure_eccentricity(tref_in=None,
 
         The keys with suffix "zeroecc" are only required for
         `ResidualAmplitude` and `ResidualFrequency` methods, where
-        "t_zeroecc" and at least one of the followings are to be provided:
+        "t_zeroecc" and one of the followings are to be provided:
 
         - "hlm_zeroecc"
         - "amplm_zeroecc" and "phaselm_zeroecc".
 
+        Note that providing "hlm_zeroecc", "amplm_zeroecc" and
+        "phaselm_zeroecc" all at the same time will raise error.
         Similar to "omegalm", the user can also provide "omegalm_zeroecc". If
         it is not provided in `dataDict`, it is computed from the given
         "hlm_zeroecc" or "phaselm_zeroecc" using finite difference method.

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -171,16 +171,14 @@ def measure_eccentricity(tref_in=None,
         "t" and at least one of the followings are mandatory:
 
         - "hlm"
-        - "amplm" and "phaselm"
-        - "amplm" and "omegalm".
+        - "amplm" and "phaselm".
 
         The keys with suffix "zeroecc" are only required for
         `ResidualAmplitude` and `ResidualFrequency` methods, where
         "t_zeroecc" and at least one of the followings are to be provided:
 
         - "hlm_zeroecc"
-        - "amplm_zeroecc" and "phaselm_zeroecc"
-        - "amplm_zeroecc" and "omegalm_zeroecc".
+        - "amplm_zeroecc" and "phaselm_zeroecc".
 
         If provided for other methods, they are used for additional
         diagnostic plots, which can be helpful for all methods. Any other
@@ -191,10 +189,10 @@ def measure_eccentricity(tref_in=None,
         - "t": 1d array of times.
 
             - Should be uniformly sampled, with a small enough time step so
-              that omega22(t) can be accurately computed. We use a 4th-order
-              finite difference scheme. In dimensionless units, we recommend a
-              time step of dtM = 0.1M to be conservative, but one may be able
-              to get away with larger time steps like dtM = 1M. The
+              that omega22(t) can be accurately computed, if necessary. We use
+              a 4th-order finite difference scheme. In dimensionless units, we
+              recommend a time step of dtM = 0.1M to be conservative, but one
+              may be able to get away with larger time steps like dtM = 1M. The
               corresponding time step in seconds would be dtM * M *
               lal.MTSUN_SI, where M is the total mass in Solar masses.
             - We do not require the waveform peak amplitude to occur at any
@@ -220,13 +218,14 @@ def measure_eccentricity(tref_in=None,
         - "phaselm": Dictionary of phases of waveform modes associated with
           "t". Should have the same format as "hlm", except that the phase is
           real. The phaselm is related to hlm as hlm = amplm * exp(- i phaselm)
-          ensuring that the phaselm is monotonically increasing.
+          ensuring that the phaselm is monotonically increasing for m > 0
+          modes.
 
         - "omegalm": Dictionary of the frequencies of the waveform modes
           associated with "t". Should have the same format as "hlm", except
           that the omegalm is real. omegalm is obtained from the phaselm (see
           above) as omegalm = d/dt phaselm, which means that the omegalm is
-          positive.
+          positive for m > 0 modes.
 
         - "t_zeroecc" and "hlm_zeroecc":
 
@@ -247,8 +246,7 @@ def measure_eccentricity(tref_in=None,
 
         - "amplm_zeroecc", "phaselm_zeroecc" and "omegalm_zeroecc":
             Same as "amplm", "phaselm" and "omegalm", respectively, but for the
-            quasicircular counterpart to the eccentric waveform.  Should have
-            same format as "hlm_zeroecc".
+            quasicircular counterpart to the eccentric waveform.
 
 
     num_orbits_to_exclude_before_merger:

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -173,6 +173,11 @@ def measure_eccentricity(tref_in=None,
         - "hlm"
         - "amplm" and "phaselm".
 
+        Apart from specifying "hlm" or "amplm" and "phaselm", the user can also
+        provide "omegalm". If the "omegalm" key is not explicitly provided, it
+        is computed from the given "hlm" or "phaselm" using finite difference
+        method.
+
         The keys with suffix "zeroecc" are only required for
         `ResidualAmplitude` and `ResidualFrequency` methods, where
         "t_zeroecc" and at least one of the followings are to be provided:
@@ -180,9 +185,16 @@ def measure_eccentricity(tref_in=None,
         - "hlm_zeroecc"
         - "amplm_zeroecc" and "phaselm_zeroecc".
 
-        If provided for other methods, they are used for additional
-        diagnostic plots, which can be helpful for all methods. Any other
-        keys in dataDict will be ignored, with a warning.
+        Similar to "omegalm", the user can also provide "omegalm_zeroecc". If
+        it is not provided in `dataDict`, it is computed from the given
+        "hlm_zeroecc" or "phaselm_zeroecc" using finite difference method.
+
+        If zeroecc data are provided for methods other than `ResidualAmplitude`
+        and `ResidualFrequency`, they are used for additional diagnostic plots,
+        which can be helpful for all methods.
+
+        Any keys in `dataDict` other than the recognized ones will be ignored,
+        with a warning.
 
         The recognized keys are:
 
@@ -223,9 +235,9 @@ def measure_eccentricity(tref_in=None,
 
         - "omegalm": Dictionary of the frequencies of the waveform modes
           associated with "t". Should have the same format as "hlm", except
-          that the omegalm is real. omegalm is obtained from the phaselm (see
-          above) as omegalm = d/dt phaselm, which means that the omegalm is
-          positive for m > 0 modes.
+          that the omegalm is real. omegalm is related the phaselm (see above)
+          as omegalm = d/dt phaselm, which means that the omegalm is positive
+          for m > 0 modes.
 
         - "t_zeroecc" and "hlm_zeroecc":
 

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -168,13 +168,12 @@ def measure_eccentricity(tref_in=None,
                         "omegalm_zeroecc": omegaDict,
                       }
 
-        "t" and one of the followings are mandatory:
+        "t" and one of the following is mandatory:
 
-        - "hlm"
-        - "amplm" and "phaselm".
+        1. "hlm" OR
+        2. "amplm" and "phaselm"
+            but not both 1 and 2 at the same time.
 
-        Note that providing "hlm" and "amplm" or "phaselm" at the same time
-        will raise error.
         Apart from specifying "hlm" or "amplm" and "phaselm", the user can also
         provide "omegalm". If the "omegalm" key is not explicitly provided, it
         is computed from the given "hlm" or "phaselm" using finite difference
@@ -182,10 +181,11 @@ def measure_eccentricity(tref_in=None,
 
         The keys with suffix "zeroecc" are only required for
         `ResidualAmplitude` and `ResidualFrequency` methods, where
-        "t_zeroecc" and one of the followings are to be provided:
+        "t_zeroecc" and one of the following is to be provided:
 
-        - "hlm_zeroecc"
-        - "amplm_zeroecc" and "phaselm_zeroecc".
+        1. "hlm_zeroecc" OR
+        2. "amplm_zeroecc" and "phaselm_zeroecc"
+            but not both 1 and 2 at the same time.
 
         Note that providing "hlm_zeroecc" and "amplm_zeroecc" or
         "phaselm_zeroecc" at the same time will raise error.

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -168,23 +168,23 @@ def measure_eccentricity(tref_in=None,
                         omegalm_zeroecc": omegaDict,
                       }
 
-            "t" and at least one of the followings are mandatory:
+        "t" and at least one of the followings are mandatory:
 
-            - "hlm"
-            - "amplm" and "phaselm"
-            - "amplm" and "omegalm".
+        - "hlm"
+        - "amplm" and "phaselm"
+        - "amplm" and "omegalm".
 
-            The keys with suffix "zeroecc" are only required for
-            `ResidualAmplitude` and `ResidualFrequency` methods, where
-            "t_zeroecc" and at least one of the followings are to be provided:
+        The keys with suffix "zeroecc" are only required for
+        `ResidualAmplitude` and `ResidualFrequency` methods, where
+        "t_zeroecc" and at least one of the followings are to be provided:
 
-            - "hlm_zeroecc"
-            - "amplm_zeroecc" and "phaselm_zeroecc"
-            - "amplm_zeroecc" and "omegalm_zeroecc".
+        - "hlm_zeroecc"
+        - "amplm_zeroecc" and "phaselm_zeroecc"
+        - "amplm_zeroecc" and "omegalm_zeroecc".
 
-            If provided for other methods, they are used for additional
-            diagnostic plots, which can be helpful for all methods. Any other
-            keys in dataDict will be ignored, with a warning.
+        If provided for other methods, they are used for additional
+        diagnostic plots, which can be helpful for all methods. Any other
+        keys in dataDict will be ignored, with a warning.
 
         The recognized keys are:
 

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -213,14 +213,20 @@ def measure_eccentricity(tref_in=None,
             waveform mode. Should contain at least the (2, 2) mode, but more
             modes can be included, as indicated by the ellipsis '...'  above.
 
-        - "amplm": Dictionary of amplitudes of waveform modes associated
-          with "t". Should have the same format as "hlm".
+        - "amplm": Dictionary of amplitudes of waveform modes associated with
+          "t". Should have the same format as "hlm", except that the amplitude
+          is real.
 
-        - "phaselm": Dictionary of phases of waveform modes associated
-          with "t". Should have the same format as "hlm".
+        - "phaselm": Dictionary of phases of waveform modes associated with
+          "t". Should have the same format as "hlm", except that the phase is
+          real. The phaselm is related to hlm as hlm = amplm * exp(- i phaselm)
+          ensuring that the phaselm is monotonically increasing.
 
         - "omegalm": Dictionary of the frequencies of the waveform modes
-          associated with "t". Should have the same format as "hlm".
+          associated with "t". Should have the same format as "hlm", except
+          that the omegalm is real. omegalm is obtained from the phaselm (see
+          above) as omegalm = d/dt phaselm, which means that the omegalm is
+          positive.
 
         - "t_zeroecc" and "hlm_zeroecc":
 

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -173,7 +173,7 @@ def measure_eccentricity(tref_in=None,
         - "hlm"
         - "amplm" and "phaselm".
 
-        Note that providing "hlm", "amplm" and "phaselm" all at the same time
+        Note that providing "hlm" and "amplm" or "phaselm" at the same time
         will raise error.
         Apart from specifying "hlm" or "amplm" and "phaselm", the user can also
         provide "omegalm". If the "omegalm" key is not explicitly provided, it
@@ -187,8 +187,8 @@ def measure_eccentricity(tref_in=None,
         - "hlm_zeroecc"
         - "amplm_zeroecc" and "phaselm_zeroecc".
 
-        Note that providing "hlm_zeroecc", "amplm_zeroecc" and
-        "phaselm_zeroecc" all at the same time will raise error.
+        Note that providing "hlm_zeroecc" and "amplm_zeroecc" or
+        "phaselm_zeroecc" at the same time will raise error.
         Similar to "omegalm", the user can also provide "omegalm_zeroecc". If
         it is not provided in `dataDict`, it is computed from the given
         "hlm_zeroecc" or "phaselm_zeroecc" using finite difference method.

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -157,32 +157,49 @@ def measure_eccentricity(tref_in=None,
         format::
 
             dataDict = {"t": time,
-                       "hlm": modeDict,
-                       "t_zeroecc": time,
-                       "hlm_zeroecc": modeDict,
-                       }
+                        "hlm": modeDict,
+                        "amplm": ampDict,
+                        "phaselm": phaseDict,
+                        "omegalm": omegaDict,
+                        "t_zeroecc": time,
+                        "hlm_zeroecc": modeDict,
+                        "amplm_zeroecc": ampDict,
+                        "phaselm_zeroecc": phaseDict,
+                        omegalm_zeroecc": omegaDict,
+                      }
 
-        "t" and "hlm" are mandatory. "t_zeroecc" and "hlm_zeroecc" are only
-        required for ResidualAmplitude and ResidualFrequency methods, but if
-        provided, they are used for additional diagnostic plots, which can be
-        helpful for all methods. Any other keys in dataDict will be ignored,
-        with a warning.
+            "t" and at least one of the followings are mandatory:
+
+            - "hlm"
+            - "amplm" and "phaselm"
+            - "amplm" and "omegalm".
+
+            The keys with suffix "zeroecc" are only required for
+            `ResidualAmplitude` and `ResidualFrequency` methods, where
+            "t_zeroecc" and at least one of the followings are to be provided:
+
+            - "hlm_zeroecc"
+            - "amplm_zeroecc" and "phaselm_zeroecc"
+            - "amplm_zeroecc" and "omegalm_zeroecc".
+
+            If provided for other methods, they are used for additional
+            diagnostic plots, which can be helpful for all methods. Any other
+            keys in dataDict will be ignored, with a warning.
 
         The recognized keys are:
 
-        - "t" : 1d array of times.
+        - "t": 1d array of times.
 
             - Should be uniformly sampled, with a small enough time step so
               that omega22(t) can be accurately computed. We use a 4th-order
               finite difference scheme. In dimensionless units, we recommend a
-              time step of dtM = 0.1M to be conservative, but you may be able
+              time step of dtM = 0.1M to be conservative, but one may be able
               to get away with larger time steps like dtM = 1M. The
-              corresponding time step in seconds would be
-              dtM * M * lal.MTSUN_SI, where M is the total mass in Solar
-              masses.
+              corresponding time step in seconds would be dtM * M *
+              lal.MTSUN_SI, where M is the total mass in Solar masses.
             - We do not require the waveform peak amplitude to occur at any
-              specific time, but tref_in should follow the same convention for
-              peak time as "t".
+              specific time, but tref_in should follow the same convention
+              for peak time as "t".
 
         - "hlm": Dictionary of waveform modes associated with "t".
             Should have the format::
@@ -193,9 +210,14 @@ def measure_eccentricity(tref_in=None,
                            }
 
             where h_{l, m} is a 1d complex array representing the (l, m)
-            waveform mode. Should contain at least the (2, 2) mode, but
-            more modes can be included, as indicated by the ellipsis '...'
-            above.
+            waveform mode. Should contain at least the (2, 2) mode, but more
+            modes can be included, as indicated by the ellipsis '...'  above.
+        - "amplm": Dictionary of amplitudes of waveform modes associated
+          with "t". Should have the same format as "hlm".
+        - "phaselm": Dictionary of phases of waveform modes associated
+          with "t". Should have the same format as "hlm".
+        - "omegalm": Dictionary of the frequencies of the waveform modes
+          associated with "t". Should have the same format as "hlm".
         - "t_zeroecc" and "hlm_zeroecc":
 
             - Same as above, but for the quasicircular counterpart to the
@@ -212,6 +234,11 @@ def measure_eccentricity(tref_in=None,
               time does not have to match that of "t".
             - We require that "hlm_zeroecc" be at least as long as "hlm" so
               that residual amplitude/frequency can be computed.
+        - "amplm_zeroecc", "phaselm_zeroecc" and "omegalm_zeroecc":
+            Same as "amplm", "phaselm" and "omegalm", respectively, but for the
+            quasicircular counterpart to the eccentric waveform.  Should have
+            same format as "hlm_zeroecc".
+
 
     num_orbits_to_exclude_before_merger:
         Can be None or a non negative number.

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -165,7 +165,7 @@ def measure_eccentricity(tref_in=None,
                         "hlm_zeroecc": modeDict,
                         "amplm_zeroecc": ampDict,
                         "phaselm_zeroecc": phaseDict,
-                        omegalm_zeroecc": omegaDict,
+                        "omegalm_zeroecc": omegaDict,
                       }
 
         "t" and at least one of the followings are mandatory:
@@ -212,12 +212,16 @@ def measure_eccentricity(tref_in=None,
             where h_{l, m} is a 1d complex array representing the (l, m)
             waveform mode. Should contain at least the (2, 2) mode, but more
             modes can be included, as indicated by the ellipsis '...'  above.
+
         - "amplm": Dictionary of amplitudes of waveform modes associated
           with "t". Should have the same format as "hlm".
+
         - "phaselm": Dictionary of phases of waveform modes associated
           with "t". Should have the same format as "hlm".
+
         - "omegalm": Dictionary of the frequencies of the waveform modes
           associated with "t". Should have the same format as "hlm".
+
         - "t_zeroecc" and "hlm_zeroecc":
 
             - Same as above, but for the quasicircular counterpart to the
@@ -234,6 +238,7 @@ def measure_eccentricity(tref_in=None,
               time does not have to match that of "t".
             - We require that "hlm_zeroecc" be at least as long as "hlm" so
               that residual amplitude/frequency can be computed.
+
         - "amplm_zeroecc", "phaselm_zeroecc" and "omegalm_zeroecc":
             Same as "amplm", "phaselm" and "omegalm", respectively, but for the
             quasicircular counterpart to the eccentric waveform.  Should have

--- a/gw_eccentricity/utils.py
+++ b/gw_eccentricity/utils.py
@@ -6,13 +6,16 @@ from scipy.interpolate import PchipInterpolator
 import warnings
 
 
-def amplitude_using_all_modes(mode_dict):
+def amplitude_using_all_modes(mode_dict, data_type="hlm"):
     """Get the amplitude using all the available modes.
 
     Parameters
     ----------
-    mode_dict:
+    mode_dict: dict
         Dictionary containing waveform modes.
+    data_type: str
+        Indicate whether the dictionary contains hlm or amplm.
+        Default is "hlm".
 
     Returns
     -------
@@ -21,7 +24,12 @@ def amplitude_using_all_modes(mode_dict):
     """
     amp = 0
     for mode in mode_dict.keys():
-        amp += np.abs(mode_dict[mode])**2
+        if data_type == "hlm":
+            amp += np.abs(mode_dict[mode])**2
+        elif data_type == "amplm":
+            amp += mode_dict[mode]**2
+        else:
+            raise KeyError("data_type must be either `hlm` or `amplm`.")
     return np.sqrt(amp)
 
 

--- a/test/test_dataDict.py
+++ b/test/test_dataDict.py
@@ -1,0 +1,127 @@
+import gw_eccentricity
+from gw_eccentricity import load_data
+from gw_eccentricity import measure_eccentricity
+from gw_eccentricity.utils import time_deriv_4thOrder
+import numpy as np
+
+
+def test_dataDict():
+    """
+    Test that the interface works for dataDict with all allowed
+    combination of keys in dataDict.
+    """
+    # Load test waveform
+    lal_kwargs = {"approximant": "EccentricTD",
+                  "q": 1.0,
+                  "chi1": [0.0, 0.0, 0.0],
+                  "chi2": [0.0, 0.0, 0.0],
+                  "Momega0": 0.01,
+                  "ecc": 0.1,
+                  "mean_ano": 0,
+                  "include_zero_ecc": True}
+    dataDict = load_data.load_waveform(**lal_kwargs)
+
+    # get amplm, phaselm, omegalm
+    phaselm = {}
+    amplm = {}
+    omegalm = {}
+    dt = dataDict["t"][1] - dataDict["t"][0]
+    for k in dataDict["hlm"]:
+        phaselm[k] = -np.unwrap(np.angle(dataDict["hlm"][k]))
+        amplm[k] = np.abs(dataDict["hlm"][k])
+        omegalm[k] = time_deriv_4thOrder(phaselm[k], dt)
+
+    # get amplm_zeroecc, phaselm_zeroecc, omegalm_zeroecc
+    phaselm_zeroecc = {}
+    amplm_zeroecc = {}
+    omegalm_zeroecc = {}
+    dt_zeroecc = dataDict["t_zeroecc"][1] - dataDict["t_zeroecc"][0]
+    for k in dataDict["hlm_zeroecc"]:
+        phaselm_zeroecc[k] = -np.unwrap(np.angle(dataDict["hlm_zeroecc"][k]))
+        amplm_zeroecc[k] = np.abs(dataDict["hlm_zeroecc"][k])
+        omegalm_zeroecc[k] = time_deriv_4thOrder(phaselm_zeroecc[k],
+                                                 dt_zeroecc)
+
+    # List of all available methods
+    available_methods = gw_eccentricity.get_available_methods()
+
+    # create data dict with hlm
+    data_hlm = {"t": dataDict["t"],
+                "hlm": dataDict["hlm"]}
+    # create data dict with amplm and phaselm
+    data_amplm_phaselm = {
+        "t": dataDict["t"],
+        "amplm": amplm,
+        "phaselm": phaselm}
+
+    for method in available_methods:
+        # Using hlm
+        if "Residual" in method:
+            # add zeroecc hlm
+            data_hlm.update({"t_zeroecc": dataDict["t_zeroecc"],
+                             "hlm_zeroecc": dataDict["hlm_zeroecc"]})
+        return_dict_hlm = measure_eccentricity(
+            tref_in=dataDict["t"],
+            method=method,
+            dataDict=data_hlm)
+        gwecc_object_hlm = return_dict_hlm["gwecc_object"]
+        eccentricity_w_hlm = gwecc_object_hlm.eccentricity
+        mean_anomaly_w_hlm = gwecc_object_hlm.mean_anomaly
+
+        # Using hlm with omegalm also provided
+        data_hlm.update({"omegalm": omegalm})
+        if "Residual" in method:
+            data_hlm.update(
+                {"omegalm_zeroecc": omegalm_zeroecc})
+        return_dict_hlm_omegalm = measure_eccentricity(
+            tref_in=dataDict["t"],
+            method=method,
+            dataDict=data_hlm)
+        gwecc_object_hlm_omegalm = return_dict_hlm_omegalm["gwecc_object"]
+        eccentricity_w_hlm_and_omegalm = gwecc_object_hlm_omegalm.eccentricity
+        mean_anomaly_w_hlm_and_omegalm = gwecc_object_hlm_omegalm.mean_anomaly
+
+        # using amplm and phaselm
+        if "Residual" in method:
+            # add zeroecc amplm and phaselm
+            data_amplm_phaselm.update(
+                {"t_zeroecc": dataDict["t_zeroecc"],
+                 "amplm_zeroecc": amplm_zeroecc,
+                 "phaselm_zeroecc": phaselm_zeroecc})
+        return_dict_amplm_phaselm = measure_eccentricity(
+            tref_in=dataDict["t"],
+            method=method,
+            dataDict=data_hlm)
+        gwecc_object_amplm_phaselm = return_dict_amplm_phaselm["gwecc_object"]
+        eccentricity_w_amplm_phaselm = gwecc_object_amplm_phaselm.eccentricity
+        mean_anomaly_w_amplm_phaselm = gwecc_object_amplm_phaselm.mean_anomaly
+
+        # Using amplm and phaselm with omegalm
+        data_amplm_phaselm.update({"omegalm": omegalm})
+        if "Residual" in method:
+            data_amplm_phaselm.update(
+                {"omegalm_zeroecc": omegalm_zeroecc})
+        return_dict_amplm_phaselm_and_omegalm = measure_eccentricity(
+            tref_in=dataDict["t"],
+            method=method,
+            dataDict=data_hlm)
+        gwecc_object_amplm_phaselm_and_omegalm = return_dict_amplm_phaselm_and_omegalm["gwecc_object"]
+        eccentricity_w_amplm_phaselm_and_omegalm = gwecc_object_amplm_phaselm_and_omegalm.eccentricity
+        mean_anomaly_w_amplm_phaselm_and_omegalm = gwecc_object_amplm_phaselm_and_omegalm.mean_anomaly
+
+        # Compare eccenrtcity and mean anomaly between hlm and amp/phase
+        np.testing.assert_allclose(eccentricity_w_hlm,
+                                   eccentricity_w_amplm_phaselm)
+        np.testing.assert_allclose(mean_anomaly_w_hlm,
+                                   mean_anomaly_w_amplm_phaselm)
+        # Compare eccenrtcity and mean anomaly using hlm with and without omega
+        np.testing.assert_allclose(eccentricity_w_hlm,
+                                   eccentricity_w_hlm_and_omegalm)
+        np.testing.assert_allclose(mean_anomaly_w_hlm,
+                                   mean_anomaly_w_hlm_and_omegalm)
+        # Compare eccenrtcity and mean anomaly using amplm and phaselm with and
+        # without omega
+        np.testing.assert_allclose(eccentricity_w_amplm_phaselm,
+                                   eccentricity_w_amplm_phaselm_and_omegalm)
+        np.testing.assert_allclose(mean_anomaly_w_amplm_phaselm,
+                                   mean_anomaly_w_amplm_phaselm_and_omegalm)

--- a/test/test_dataDict.py
+++ b/test/test_dataDict.py
@@ -25,40 +25,30 @@ def test_dataDict():
     phaselm = {}
     amplm = {}
     omegalm = {}
-    dt = dataDict["t"][1] - dataDict["t"][0]
     # check that the time array is uniform. This is required to obtain omega by
     # taking derivative of phase applying time_deriv_4thorder.
-    ids = np.where(np.abs(np.diff(dataDict["t"]) - dt) > 1e-7)[0]
-    if len(ids) > 0:
-        dt_ = np.diff(dataDict["t"])[ids[0]]
-        raise Exception("t is not uniform. dt at the start of the "
-                        f"time array is {dt}. dt={dt_} between index "
-                        f"{ids[0]} and {ids[0]+1}. The difference is "
-                        f"{dt - dt_}")
+    t_diff = np.diff(dataDict["t"])
+    if not np.allclose(t_diff, t_diff[0]):
+        raise Exception("Input time array must have uniform time steps.\n"
+                        f"Time steps are {t_diff}")
     for k in dataDict["hlm"]:
         phaselm[k] = -np.unwrap(np.angle(dataDict["hlm"][k]))
         amplm[k] = np.abs(dataDict["hlm"][k])
-        omegalm[k] = time_deriv_4thOrder(phaselm[k], dt)
+        omegalm[k] = time_deriv_4thOrder(phaselm[k], t_diff[0])
 
     # get amplm_zeroecc, phaselm_zeroecc, omegalm_zeroecc
     phaselm_zeroecc = {}
     amplm_zeroecc = {}
     omegalm_zeroecc = {}
-    dt_zeroecc = dataDict["t_zeroecc"][1] - dataDict["t_zeroecc"][0]
-    # check that t_zeroecc is uniform
-    ids = np.where(np.abs(np.diff(dataDict["t_zeroecc"]) - dt_zeroecc)
-                   > 1e-7)[0]
-    if len(ids) > 0:
-        dt_zeroecc_ = np.diff(dataDict["t_zeroecc"])[ids[0]]
-        raise Exception("t_zeroecc is not uniform. dt at the start of the "
-                        f"time array is {dt_zeroecc}. dt={dt_zeroecc_} "
-                        f"between index {ids[0]} and {ids[0]+1}. The "
-                        f"difference is {dt_zeroecc - dt_zeroecc_}")
+    t_zeroecc_diff = np.diff(dataDict["t_zeroecc"])
+    if not np.allclose(t_zeroecc_diff, t_zeroecc_diff[0]):
+        raise Exception("Input time array must have uniform time steps.\n"
+                        f"Time steps are {t_zeroecc_diff}")
     for k in dataDict["hlm_zeroecc"]:
         phaselm_zeroecc[k] = -np.unwrap(np.angle(dataDict["hlm_zeroecc"][k]))
         amplm_zeroecc[k] = np.abs(dataDict["hlm_zeroecc"][k])
         omegalm_zeroecc[k] = time_deriv_4thOrder(phaselm_zeroecc[k],
-                                                 dt_zeroecc)
+                                                 t_zeroecc_diff[0])
 
     # List of all available methods
     available_methods = gw_eccentricity.get_available_methods()

--- a/test/test_dataDict.py
+++ b/test/test_dataDict.py
@@ -26,6 +26,14 @@ def test_dataDict():
     amplm = {}
     omegalm = {}
     dt = dataDict["t"][1] - dataDict["t"][0]
+    # check that the time array is uniform. This is required to obtain omega by
+    # taking derivative of phase applying time_deriv_4thorder.
+    ids = np.where(np.abs(np.diff(dataDict["t"]) - dt) > 1e-7)[0]
+    if len(ids) > 0:
+        dt_ = np.diff(dataDict["t"])[ids[0]]
+        raise Exception("t_zeroecc is not uniform. dt at the start of the "
+                        f"time array is {dt}. dt={dt_} between {ids[0]} and "
+                        f"{ids[0]+1}. The difference is {dt - dt_}")
     for k in dataDict["hlm"]:
         phaselm[k] = -np.unwrap(np.angle(dataDict["hlm"][k]))
         amplm[k] = np.abs(dataDict["hlm"][k])
@@ -36,6 +44,15 @@ def test_dataDict():
     amplm_zeroecc = {}
     omegalm_zeroecc = {}
     dt_zeroecc = dataDict["t_zeroecc"][1] - dataDict["t_zeroecc"][0]
+    # check that t_zeroecc is uniform
+    ids = np.where(np.abs(np.diff(dataDict["t_zeroecc"]) - dt_zeroecc)
+                   > 1e-7)[0]
+    if len(ids) > 0:
+        dt_zeroecc_ = np.diff(dataDict["t_zeroecc"])[ids[0]]
+        raise Exception("t_zeroecc is not uniform. dt at the start of the "
+                        f"time array is {dt_zeroecc}. dt={dt_zeroecc_} "
+                        f"between {ids[0]} and {ids[0]+1}. The difference is "
+                        f"{dt_zeroecc - dt_zeroecc_}")
     for k in dataDict["hlm_zeroecc"]:
         phaselm_zeroecc[k] = -np.unwrap(np.angle(dataDict["hlm_zeroecc"][k]))
         amplm_zeroecc[k] = np.abs(dataDict["hlm_zeroecc"][k])
@@ -46,10 +63,11 @@ def test_dataDict():
     available_methods = gw_eccentricity.get_available_methods()
 
     # create data dict with hlm
-    data_hlm = {"t": dataDict["t"],
-                "hlm": dataDict["hlm"]}
+    data_w_hlm = {
+        "t": dataDict["t"],
+        "hlm": dataDict["hlm"]}
     # create data dict with amplm and phaselm
-    data_amplm_phaselm = {
+    data_w_amplm_phaselm = {
         "t": dataDict["t"],
         "amplm": amplm,
         "phaselm": phaselm}
@@ -58,56 +76,57 @@ def test_dataDict():
         # Using hlm
         if "Residual" in method:
             # add zeroecc hlm
-            data_hlm.update({"t_zeroecc": dataDict["t_zeroecc"],
-                             "hlm_zeroecc": dataDict["hlm_zeroecc"]})
-        return_dict_hlm = measure_eccentricity(
+            data_w_hlm.update({
+                "t_zeroecc": dataDict["t_zeroecc"],
+                "hlm_zeroecc": dataDict["hlm_zeroecc"]})
+        result_w_hlm = measure_eccentricity(
             tref_in=dataDict["t"],
             method=method,
-            dataDict=data_hlm)
-        gwecc_object_hlm = return_dict_hlm["gwecc_object"]
-        eccentricity_w_hlm = gwecc_object_hlm.eccentricity
-        mean_anomaly_w_hlm = gwecc_object_hlm.mean_anomaly
+            dataDict=data_w_hlm)
+        gwecc_object_w_hlm = result_w_hlm["gwecc_object"]
+        eccentricity_w_hlm = gwecc_object_w_hlm.eccentricity
+        mean_anomaly_w_hlm = gwecc_object_w_hlm.mean_anomaly
 
         # Using hlm with omegalm also provided
-        data_hlm.update({"omegalm": omegalm})
+        data_w_hlm.update({"omegalm": omegalm})
         if "Residual" in method:
-            data_hlm.update(
+            data_w_hlm.update(
                 {"omegalm_zeroecc": omegalm_zeroecc})
-        return_dict_hlm_omegalm = measure_eccentricity(
+        result_w_hlm_omegalm = measure_eccentricity(
             tref_in=dataDict["t"],
             method=method,
-            dataDict=data_hlm)
-        gwecc_object_hlm_omegalm = return_dict_hlm_omegalm["gwecc_object"]
-        eccentricity_w_hlm_and_omegalm = gwecc_object_hlm_omegalm.eccentricity
-        mean_anomaly_w_hlm_and_omegalm = gwecc_object_hlm_omegalm.mean_anomaly
+            dataDict=data_w_hlm)
+        gwecc_object_w_hlm_omegalm = result_w_hlm_omegalm["gwecc_object"]
+        eccentricity_w_hlm_and_omegalm = gwecc_object_w_hlm_omegalm.eccentricity
+        mean_anomaly_w_hlm_and_omegalm = gwecc_object_w_hlm_omegalm.mean_anomaly
 
         # using amplm and phaselm
         if "Residual" in method:
             # add zeroecc amplm and phaselm
-            data_amplm_phaselm.update(
+            data_w_amplm_phaselm.update(
                 {"t_zeroecc": dataDict["t_zeroecc"],
                  "amplm_zeroecc": amplm_zeroecc,
                  "phaselm_zeroecc": phaselm_zeroecc})
-        return_dict_amplm_phaselm = measure_eccentricity(
+        result_w_amplm_phaselm = measure_eccentricity(
             tref_in=dataDict["t"],
             method=method,
-            dataDict=data_hlm)
-        gwecc_object_amplm_phaselm = return_dict_amplm_phaselm["gwecc_object"]
-        eccentricity_w_amplm_phaselm = gwecc_object_amplm_phaselm.eccentricity
-        mean_anomaly_w_amplm_phaselm = gwecc_object_amplm_phaselm.mean_anomaly
+            dataDict=data_w_hlm)
+        gwecc_object_w_amplm_phaselm = result_w_amplm_phaselm["gwecc_object"]
+        eccentricity_w_amplm_phaselm = gwecc_object_w_amplm_phaselm.eccentricity
+        mean_anomaly_w_amplm_phaselm = gwecc_object_w_amplm_phaselm.mean_anomaly
 
         # Using amplm and phaselm with omegalm
-        data_amplm_phaselm.update({"omegalm": omegalm})
+        data_w_amplm_phaselm.update({"omegalm": omegalm})
         if "Residual" in method:
-            data_amplm_phaselm.update(
+            data_w_amplm_phaselm.update(
                 {"omegalm_zeroecc": omegalm_zeroecc})
-        return_dict_amplm_phaselm_and_omegalm = measure_eccentricity(
+        result_w_amplm_phaselm_and_omegalm = measure_eccentricity(
             tref_in=dataDict["t"],
             method=method,
-            dataDict=data_hlm)
-        gwecc_object_amplm_phaselm_and_omegalm = return_dict_amplm_phaselm_and_omegalm["gwecc_object"]
-        eccentricity_w_amplm_phaselm_and_omegalm = gwecc_object_amplm_phaselm_and_omegalm.eccentricity
-        mean_anomaly_w_amplm_phaselm_and_omegalm = gwecc_object_amplm_phaselm_and_omegalm.mean_anomaly
+            dataDict=data_w_hlm)
+        gwecc_object_w_amplm_phaselm_and_omegalm = result_w_amplm_phaselm_and_omegalm["gwecc_object"]
+        eccentricity_w_amplm_phaselm_and_omegalm = gwecc_object_w_amplm_phaselm_and_omegalm.eccentricity
+        mean_anomaly_w_amplm_phaselm_and_omegalm = gwecc_object_w_amplm_phaselm_and_omegalm.mean_anomaly
 
         # Compare eccenrtcity and mean anomaly between hlm and amp/phase
         np.testing.assert_allclose(eccentricity_w_hlm,

--- a/test/test_dataDict.py
+++ b/test/test_dataDict.py
@@ -3,6 +3,50 @@ from gw_eccentricity import load_data
 from gw_eccentricity import measure_eccentricity
 from gw_eccentricity.utils import time_deriv_4thOrder
 import numpy as np
+import copy
+
+
+def compare_eccentricity_measurement(dataDict1, dataDict2, method):
+    """Compare the measured eccentricity and mean anomaly.
+
+    Eccentricity measurement can take different combination of waveform data.
+    Two input dictionaries with different but allowed combination of data from
+    the same waveform should result in the same measured eccentricity and mean
+    anomaly.
+
+    Parameters
+    ----------
+    dataDict1 : dict
+        Dictionary with allowed combination of waveform data.
+    dataDict2 : dict
+        Dictionary with allowed combination of waveform data.
+    method: str
+        Method to use for eccentricity measurement.
+    """
+    # Check that both the dataDict has same time arrays
+    if any(dataDict1["t"] != dataDict2["t"]):
+        raise Exception("The dataDicts must have the same time array.")
+    result1 = measure_eccentricity(
+        tref_in=dataDict1["t"],
+        method=method,
+        dataDict=dataDict1)
+    gwecc_object1 = result1["gwecc_object"]
+    eccentricity1 = gwecc_object1.eccentricity
+    mean_anomaly1 = gwecc_object1.mean_anomaly
+
+    result2 = measure_eccentricity(
+        tref_in=dataDict1["t"],
+        method=method,
+        dataDict=dataDict2)
+    gwecc_object2 = result2["gwecc_object"]
+    eccentricity2 = gwecc_object2.eccentricity
+    mean_anomaly2 = gwecc_object2.mean_anomaly
+
+    # Compare the eccenrtcity and mean anaomaly
+    np.testing.assert_allclose(eccentricity1,
+                               eccentricity2)
+    np.testing.assert_allclose(mean_anomaly1,
+                               mean_anomaly2)
 
 
 def test_dataDict():
@@ -54,84 +98,106 @@ def test_dataDict():
     available_methods = gw_eccentricity.get_available_methods()
 
     # create data dict with hlm
-    data_w_hlm = {
+    dataDict1_w_hlm = {
         "t": dataDict["t"],
         "hlm": dataDict["hlm"]}
+    # create data dict with hlm and omegalm
+    dataDict2_w_hlm_and_omega = copy.deepcopy(dataDict1_w_hlm)
+    dataDict2_w_hlm_and_omega.update({"omegalm": omegalm})
     # create data dict with amplm and phaselm
-    data_w_amplm_phaselm = {
+    dataDict2_w_amplm_phaselm = {
         "t": dataDict["t"],
         "amplm": amplm,
         "phaselm": phaselm}
+    # create data dict with amplm, phaselm and omegalm
+    dataDict2_w_amplm_phaselm_and_omegalm = copy.deepcopy(
+        dataDict2_w_amplm_phaselm)
+    dataDict2_w_amplm_phaselm_and_omegalm.update({"omegalm": omegalm})
 
-    for method in available_methods:
-        # Using hlm
-        if "Residual" in method:
-            # add zeroecc hlm
-            data_w_hlm.update({
-                "t_zeroecc": dataDict["t_zeroecc"],
-                "hlm_zeroecc": dataDict["hlm_zeroecc"]})
-        result_w_hlm = measure_eccentricity(
-            tref_in=dataDict["t"],
-            method=method,
-            dataDict=data_w_hlm)
-        gwecc_object_w_hlm = result_w_hlm["gwecc_object"]
-        eccentricity_w_hlm = gwecc_object_w_hlm.eccentricity
-        mean_anomaly_w_hlm = gwecc_object_w_hlm.mean_anomaly
-
-        # Using hlm with omegalm also provided
-        data_w_hlm.update({"omegalm": omegalm})
-        if "Residual" in method:
-            data_w_hlm.update(
-                {"omegalm_zeroecc": omegalm_zeroecc})
-        result_w_hlm_omegalm = measure_eccentricity(
-            tref_in=dataDict["t"],
-            method=method,
-            dataDict=data_w_hlm)
-        gwecc_object_w_hlm_omegalm = result_w_hlm_omegalm["gwecc_object"]
-        eccentricity_w_hlm_and_omegalm = gwecc_object_w_hlm_omegalm.eccentricity
-        mean_anomaly_w_hlm_and_omegalm = gwecc_object_w_hlm_omegalm.mean_anomaly
-
-        # using amplm and phaselm
-        if "Residual" in method:
-            # add zeroecc amplm and phaselm
-            data_w_amplm_phaselm.update(
-                {"t_zeroecc": dataDict["t_zeroecc"],
-                 "amplm_zeroecc": amplm_zeroecc,
-                 "phaselm_zeroecc": phaselm_zeroecc})
-        result_w_amplm_phaselm = measure_eccentricity(
-            tref_in=dataDict["t"],
-            method=method,
-            dataDict=data_w_hlm)
-        gwecc_object_w_amplm_phaselm = result_w_amplm_phaselm["gwecc_object"]
-        eccentricity_w_amplm_phaselm = gwecc_object_w_amplm_phaselm.eccentricity
-        mean_anomaly_w_amplm_phaselm = gwecc_object_w_amplm_phaselm.mean_anomaly
-
-        # Using amplm and phaselm with omegalm
-        data_w_amplm_phaselm.update({"omegalm": omegalm})
-        if "Residual" in method:
-            data_w_amplm_phaselm.update(
-                {"omegalm_zeroecc": omegalm_zeroecc})
-        result_w_amplm_phaselm_and_omegalm = measure_eccentricity(
-            tref_in=dataDict["t"],
-            method=method,
-            dataDict=data_w_hlm)
-        gwecc_object_w_amplm_phaselm_and_omegalm = result_w_amplm_phaselm_and_omegalm["gwecc_object"]
-        eccentricity_w_amplm_phaselm_and_omegalm = gwecc_object_w_amplm_phaselm_and_omegalm.eccentricity
-        mean_anomaly_w_amplm_phaselm_and_omegalm = gwecc_object_w_amplm_phaselm_and_omegalm.mean_anomaly
-
-        # Compare eccenrtcity and mean anomaly between hlm and amp/phase
-        np.testing.assert_allclose(eccentricity_w_hlm,
-                                   eccentricity_w_amplm_phaselm)
-        np.testing.assert_allclose(mean_anomaly_w_hlm,
-                                   mean_anomaly_w_amplm_phaselm)
-        # Compare eccenrtcity and mean anomaly using hlm with and without omega
-        np.testing.assert_allclose(eccentricity_w_hlm,
-                                   eccentricity_w_hlm_and_omegalm)
-        np.testing.assert_allclose(mean_anomaly_w_hlm,
-                                   mean_anomaly_w_hlm_and_omegalm)
-        # Compare eccenrtcity and mean anomaly using amplm and phaselm with and
-        # without omega
-        np.testing.assert_allclose(eccentricity_w_amplm_phaselm,
-                                   eccentricity_w_amplm_phaselm_and_omegalm)
-        np.testing.assert_allclose(mean_anomaly_w_amplm_phaselm,
-                                   mean_anomaly_w_amplm_phaselm_and_omegalm)
+    # We loop over different data dict and compare the eccenrtcity measurement
+    # It checks that the eccenrtcity measurement is the same when we provide
+    # any of the following combinations:
+    # - only hlm
+    # - hlm and omegalm
+    # - only amplm and phaselm
+    # - amplm, phaselm and omegalm
+    for dataDict2 in [dataDict2_w_hlm_and_omega,
+                      dataDict2_w_amplm_phaselm,
+                      dataDict2_w_amplm_phaselm_and_omegalm]:
+        # Loop over the different methods
+        for method in available_methods:
+            if "Residual" in method:
+                # To avoid exception for residual method since the data does
+                # not contain zeroecc data
+                continue
+            # use data_w_hlm as dataDict1
+            compare_eccentricity_measurement(dataDict1=dataDict1_w_hlm,
+                                             dataDict2=dataDict2,
+                                             method=method)
+    # Now we repeat the same as above but adding hlm_zeroecc to both the data
+    # dict.
+    # Add hlm_zeroecc to dataDict1 first so that dataDict1 now contains
+    # hlm and hlm_zeroecc.
+    dataDict1_w_hlm_zeroecc = copy.deepcopy(dataDict1_w_hlm)
+    dataDict1_w_hlm_zeroecc.update(
+        {"t_zeroecc": dataDict["t_zeroecc"],
+         "hlm_zeroecc": dataDict["hlm_zeroecc"]})
+    # The following checks that the eccenrtcity measurement is the same
+    # when we provide:
+    # - hlm and hlm_zeroecc with or without omega_zeroecc
+    # - hlm, omegalm and hlm_zeroecc with or without omega_zeroecc
+    # - amplm, phaselm and hlm_zeroecc with or without omega_zeroecc
+    # - amplm, phaselm, omegalm and hlm_zeroecc with or without omega_zeroecc
+    for dataDict2 in [dataDict2_w_hlm_and_omega,
+                      dataDict2_w_amplm_phaselm,
+                      dataDict2_w_amplm_phaselm_and_omegalm]:
+        dataDict2_w_hlm_zeroecc = copy.deepcopy(dataDict2)
+        dataDict2_w_hlm_zeroecc.update(
+            {"t_zeroecc": dataDict["t_zeroecc"],
+             "hlm_zeroecc": dataDict["hlm_zeroecc"]})
+        # add omegalm_zeroecc also
+        dataDict2_w_hlm_zeroecc_and_omegalm_zeroecc = copy.deepcopy(
+            dataDict2_w_hlm_zeroecc)
+        dataDict2_w_hlm_zeroecc_and_omegalm_zeroecc.update(
+            {"omegalm_zeroecc": omegalm_zeroecc})
+        # Loop over the different methods
+        for method in available_methods:
+            compare_eccentricity_measurement(
+                dataDict1=dataDict1_w_hlm_zeroecc,
+                dataDict2=dataDict2_w_hlm_zeroecc,
+                method=method)
+            compare_eccentricity_measurement(
+                dataDict1=dataDict1_w_hlm_zeroecc,
+                dataDict2=dataDict2_w_hlm_zeroecc_and_omegalm_zeroecc,
+                method=method)
+    # This time instead of adding hlm_zeroecc, we add amplm_zeroecc and
+    # phaselm_zeroecc to dataDict2, dataDict1 is the same as above.
+    # The following checks that the eccenrtcity measurement is the same
+    # when we provide:
+    # - hlm and hlm_zeroecc with or without omega_zeroecc
+    # - hlm, omegalm, amplm_zeroecc and phaselm_zeroecc with or without omega_zeroecc
+    # - amplm, phaselm, amplm_zeroecc and phaselm_zeroecc with or without omega_zeroecc
+    # - amplm, phaselm, omegalm, amplm_zeroecc and phaselm_zeroecc with or without omega_zeroecc
+    for dataDict2 in [dataDict2_w_hlm_and_omega,
+                      dataDict2_w_amplm_phaselm,
+                      dataDict2_w_amplm_phaselm_and_omegalm]:
+        dataDict2_w_amplm_and_phaselm_zeroecc = copy.deepcopy(dataDict2)
+        dataDict2_w_amplm_and_phaselm_zeroecc.update(
+            {"t_zeroecc": dataDict["t_zeroecc"],
+             "amplm_zeroecc": amplm_zeroecc,
+             "phaselm_zeroecc": phaselm_zeroecc})
+        # add omegalm_zeroecc also
+        dataDict2_w_amplm_and_phaselm_and_omegalm_zeroecc = copy.deepcopy(
+            dataDict2_w_amplm_and_phaselm_zeroecc)
+        dataDict2_w_amplm_and_phaselm_and_omegalm_zeroecc.update(
+            {"omegalm_zeroecc": omegalm_zeroecc})
+        # Loop over the different methods
+        for method in available_methods:
+            compare_eccentricity_measurement(
+                dataDict1=dataDict1_w_hlm_zeroecc,
+                dataDict2=dataDict2_w_amplm_and_phaselm_zeroecc,
+                method=method)
+            compare_eccentricity_measurement(
+                dataDict1=dataDict1_w_hlm_zeroecc,
+                dataDict2=dataDict2_w_amplm_and_phaselm_and_omegalm_zeroecc,
+                method=method)

--- a/test/test_dataDict.py
+++ b/test/test_dataDict.py
@@ -31,9 +31,10 @@ def test_dataDict():
     ids = np.where(np.abs(np.diff(dataDict["t"]) - dt) > 1e-7)[0]
     if len(ids) > 0:
         dt_ = np.diff(dataDict["t"])[ids[0]]
-        raise Exception("t_zeroecc is not uniform. dt at the start of the "
-                        f"time array is {dt}. dt={dt_} between {ids[0]} and "
-                        f"{ids[0]+1}. The difference is {dt - dt_}")
+        raise Exception("t is not uniform. dt at the start of the "
+                        f"time array is {dt}. dt={dt_} between index "
+                        f"{ids[0]} and {ids[0]+1}. The difference is "
+                        f"{dt - dt_}")
     for k in dataDict["hlm"]:
         phaselm[k] = -np.unwrap(np.angle(dataDict["hlm"][k]))
         amplm[k] = np.abs(dataDict["hlm"][k])
@@ -51,8 +52,8 @@ def test_dataDict():
         dt_zeroecc_ = np.diff(dataDict["t_zeroecc"])[ids[0]]
         raise Exception("t_zeroecc is not uniform. dt at the start of the "
                         f"time array is {dt_zeroecc}. dt={dt_zeroecc_} "
-                        f"between {ids[0]} and {ids[0]+1}. The difference is "
-                        f"{dt_zeroecc - dt_zeroecc_}")
+                        f"between index {ids[0]} and {ids[0]+1}. The "
+                        f"difference is {dt_zeroecc - dt_zeroecc_}")
     for k in dataDict["hlm_zeroecc"]:
         phaselm_zeroecc[k] = -np.unwrap(np.angle(dataDict["hlm_zeroecc"][k]))
         amplm_zeroecc[k] = np.abs(dataDict["hlm_zeroecc"][k])

--- a/test/test_dataDict.py
+++ b/test/test_dataDict.py
@@ -42,7 +42,7 @@ def compare_eccentricity_measurement(dataDict1, dataDict2, method):
     eccentricity2 = gwecc_object2.eccentricity
     mean_anomaly2 = gwecc_object2.mean_anomaly
 
-    # Compare the eccenrtcity and mean anaomaly
+    # Compare the eccentricity and mean anomaly
     np.testing.assert_allclose(eccentricity1,
                                eccentricity2)
     np.testing.assert_allclose(mean_anomaly1,
@@ -114,8 +114,8 @@ def test_dataDict():
         dataDict2_w_amplm_phaselm)
     dataDict2_w_amplm_phaselm_and_omegalm.update({"omegalm": omegalm})
 
-    # We loop over different data dict and compare the eccenrtcity measurement
-    # It checks that the eccenrtcity measurement is the same when we provide
+    # We loop over different data dict and compare the eccentricity measurement
+    # It checks that the eccentricity measurement is the same when we provide
     # any of the following combinations:
     # - only hlm
     # - hlm and omegalm
@@ -142,12 +142,12 @@ def test_dataDict():
     dataDict1_w_hlm_zeroecc.update(
         {"t_zeroecc": dataDict["t_zeroecc"],
          "hlm_zeroecc": dataDict["hlm_zeroecc"]})
-    # The following checks that the eccenrtcity measurement is the same
+    # The following checks that the eccentricity measurement is the same
     # when we provide:
-    # - hlm and hlm_zeroecc with or without omega_zeroecc
-    # - hlm, omegalm and hlm_zeroecc with or without omega_zeroecc
-    # - amplm, phaselm and hlm_zeroecc with or without omega_zeroecc
-    # - amplm, phaselm, omegalm and hlm_zeroecc with or without omega_zeroecc
+    # - hlm and hlm_zeroecc with or without omegalm_zeroecc
+    # - hlm, omegalm and hlm_zeroecc with or without omegalm_zeroecc
+    # - amplm, phaselm and hlm_zeroecc with or without omegalm_zeroecc
+    # - amplm, phaselm, omegalm and hlm_zeroecc with or without omegalm_zeroecc
     for dataDict2 in [dataDict2_w_hlm_and_omega,
                       dataDict2_w_amplm_phaselm,
                       dataDict2_w_amplm_phaselm_and_omegalm]:
@@ -172,12 +172,12 @@ def test_dataDict():
                 method=method)
     # This time instead of adding hlm_zeroecc, we add amplm_zeroecc and
     # phaselm_zeroecc to dataDict2, dataDict1 is the same as above.
-    # The following checks that the eccenrtcity measurement is the same
+    # The following checks that the eccentricity measurement is the same
     # when we provide:
-    # - hlm and hlm_zeroecc with or without omega_zeroecc
-    # - hlm, omegalm, amplm_zeroecc and phaselm_zeroecc with or without omega_zeroecc
-    # - amplm, phaselm, amplm_zeroecc and phaselm_zeroecc with or without omega_zeroecc
-    # - amplm, phaselm, omegalm, amplm_zeroecc and phaselm_zeroecc with or without omega_zeroecc
+    # - hlm and hlm_zeroecc with or without omegalm_zeroecc
+    # - hlm, omegalm, amplm_zeroecc and phaselm_zeroecc with or without omegalm_zeroecc
+    # - amplm, phaselm, amplm_zeroecc and phaselm_zeroecc with or without omegalm_zeroecc
+    # - amplm, phaselm, omegalm, amplm_zeroecc and phaselm_zeroecc with or without omegalm_zeroecc
     for dataDict2 in [dataDict2_w_hlm_and_omega,
                       dataDict2_w_amplm_phaselm,
                       dataDict2_w_amplm_phaselm_and_omegalm]:


### PR DESCRIPTION
Addresses #60. Allows providing `amplm`, `omegalm`, `phaselm` in `dataDict`. If all of these or a subset of these are provided, new functions are added to prioritize which data to use.