### PR TITLE
set ecc to zero for failures t/f > tmax/fmax

### DIFF
--- a/test/test_set_failures_to_zero.py
+++ b/test/test_set_failures_to_zero.py
@@ -84,3 +84,69 @@ def test_set_failures_to_zero():
             np.testing.assert_allclose(
                 meanano_ref, 0.0 if ref == "scalar"
                 else np.zeros(len(fref_in[ref])))
+
+
+def test_set_failures_to_zero_for_decayed_eccentricity():
+    """Test that the interface works with set_failures_to_zero for tref/fref
+    greater than the tmax/fmax.
+
+    In certain situations, the maximum allowed time `tmax` or the maximum
+    allowed frequency `fmax` could be much smaller compared to the merger
+    time/frequency. Therefore, measurement of eccentricity closer to merger,
+    i.e., tref_in > tmax or fref_in > fmax would fail.
+
+    In cases where such a situation occurs, and if the user has
+    set 'set_failures_to_zero' to `True` in the 'extra_kwargs' parameter, both
+    the eccentricity and mean anomaly will be set to zero.
+    """
+    # We will use an EccentricTD waveform such that the Amplitude/Frequency
+    # method can find a few initial pericenetrs/apoceneters but not all of them
+    # so that tmax/fmax will be much earlier than the merger time/frequency.
+    lal_kwargs = {"approximant": "EccentricTD",
+                  "q": 1.0,
+                  "chi1": [0.0, 0.0, 0.0],
+                  "chi2": [0.0, 0.0, 0.0],
+                  "Momega0": 0.01,
+                  "ecc": 0.01,
+                  "mean_ano": 0.0,
+                  "include_zero_ecc": True}
+    # We want to test it with both a single reference point
+    # as well as an array of reference points
+    tref_in = {"scalar": -2000.0,
+               "array": np.arange(-2000.0, 0.)}
+    fref_in = {"scalar": 0.01,
+               "array": np.arange(0.01, 0.02, 0.005)}
+    dataDict = load_data.load_waveform(**lal_kwargs)
+    extra_kwargs = {"set_failures_to_zero": True}
+    for method in ["Amplitude", "Frequency"]:
+        for ref in tref_in:
+            gwecc_dict = measure_eccentricity(
+                tref_in=tref_in[ref],
+                method=method,
+                dataDict=dataDict,
+                extra_kwargs=extra_kwargs)
+            tref_out = gwecc_dict["tref_out"]
+            ecc_ref = gwecc_dict["eccentricity"]
+            meanano_ref = gwecc_dict["mean_anomaly"]
+            np.testing.assert_allclose(
+                ecc_ref, 0.0 if ref == "scalar"
+                else np.zeros(len(tref_in[ref])))
+            np.testing.assert_allclose(
+                meanano_ref, 0.0 if ref == "scalar"
+                else np.zeros(len(tref_in[ref])))
+        # test for reference frequency
+        for ref in fref_in:
+            gwecc_dict = measure_eccentricity(
+                fref_in=fref_in[ref],
+                method=method,
+                dataDict=dataDict,
+                extra_kwargs=extra_kwargs)
+            fref_out = gwecc_dict["fref_out"]
+            ecc_ref = gwecc_dict["eccentricity"]
+            meanano_ref = gwecc_dict["mean_anomaly"]
+            np.testing.assert_allclose(
+                ecc_ref, 0.0 if ref == "scalar"
+                else np.zeros(len(fref_in[ref])))
+            np.testing.assert_allclose(
+                meanano_ref, 0.0 if ref == "scalar"
+                else np.zeros(len(fref_in[ref])))


### PR DESCRIPTION
Addressing #206. For methods like `Amplitude` or `Frequency`, it could be challenging to detect the small oscillations in the later part of the inspiral and therefore the maximum allowed time `tmax` or frequency `fmax` could be much smaller than the time/frequency near merger. Therefore, for time/frequency after tmax/fmax, eccentricity can not be measured. If `set_failures_to_zero` is True, we set the eccentricity/mean anomaly to zero for such cases at these times/frequencies.