### PR TITLE
add rational fits

### DIFF
--- a/gw_eccentricity/utils.py
+++ b/gw_eccentricity/utils.py
@@ -1,6 +1,7 @@
 """Useful functions for the project."""
 import numpy as np
 import argparse
+from polyrat import StabilizedSKRationalApproximation
 from scipy.interpolate import InterpolatedUnivariateSpline
 from scipy.interpolate import PchipInterpolator
 import warnings
@@ -315,6 +316,37 @@ def get_interpolant(oldX,
         raise ValueError(f"Unknown interpolator {interpolator}. Must be one"
                          " of ['spline', 'monotonic_spline']")
     return interpolant
+
+
+def get_default_rational_fit_kwargs():
+    """Get default kwargs for rational fit."""
+    default_rational_fit_kwargs = {
+        "num_degree": None,
+        "denom_degree": None,
+        "norm": 2,
+        "maxiter": 20,
+        "verbose": False,
+        "xtol": 1e-07,
+    }
+    return default_rational_fit_kwargs
+
+
+def get_rational_fit(x, y, rational_fit_kwargs=None, check_kwargs=True):
+    """Get rational fit for the data set (x, y).
+
+    We use `polyrat.StabilizedSKRationalApproximation` to obtain
+    rational fit to the data.
+    """
+    if check_kwargs:
+        rational_fit_kwargs = check_kwargs_and_set_defaults(
+            rational_fit_kwargs,
+            get_default_rational_fit_kwargs(),
+            "rational_fit_kwargs",
+            "utils.get_default_rational_fit_kwargs"
+        )
+    rat = StabilizedSKRationalApproximation(**rational_fit_kwargs)
+    rat.fit(x.reshape(-1, 1), y)
+    return lambda x: rat(x.astype('float64').reshape(-1, 1))
 
 
 def debug_message(message, debug_level, important=True,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setuptools.setup(
         'scipy',
         'h5py',
         'lalsuite',
-        'sxs'
+        'sxs',
+        'polyrat'
     ],
     classifiers=[
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
Add `rational fit` as a fallback option to `Spline` when the interpolant of the `omega` extrema is not sufficiently smooth and its first derivative is nonmonotonic.