### PR TITLE
Add option to remove memory from sxs waveforms

### DIFF
--- a/gw_eccentricity/load_data.py
+++ b/gw_eccentricity/load_data.py
@@ -506,14 +506,13 @@ def get_defaults_for_nr():
 
     metadata_path: str
         NOTE: Only for SXS catalog format waveform.
-        Path to the sxs metadata file. This file generally can be
-        found in the same directory as the waveform file and has the
-        name `metadata.txt`. It contains the metadata including binary
-        parameters along with other information related to the NR
-        simulation performed to obtain the waveform modes.
-        Required when `include_zero_ecc` is True.
-        If provided, a dictionary containing binary mass ratio and
-        spins is returned.
+        Path to the sxs metadata file. This file generally can be found in the
+        same directory as the waveform file and has the name `metadata.txt` or
+        `metadata.json`. It contains the metadata including binary parameters
+        along with other information related to the NR simulation performed to
+        obtain the waveform modes.  Required when `include_zero_ecc` is True.
+        If provided, a dictionary containing binary mass ratio and spins is
+        returned.
         Default is None.
 
     num_orbits_to_remove_as_junk: float
@@ -762,8 +761,8 @@ def load_sxs_catalogformat(**kwargs):
 
         1. The strain file `Strain_N{extrap_order}.h5` (required)
         2. The corresponding json file `Strain_N{extrap_order}.json` (required)
-        3. The metadata file `metadata.txt` (required when `include_zero_ecc`
-          or `include_params_dict` is True)
+        3. The metadata file `metadata.txt` or `metadata.json` (required when
+          `include_zero_ecc` or `include_params_dict` or `remove_memory` is True)
         4. The horizon file `Horizons.h5` (optional)
 
         `Strain_N{extrap_order}.h5` contains the waveform extrapolated to
@@ -771,9 +770,10 @@ def load_sxs_catalogformat(**kwargs):
         drift. This and `Strain_N{extrap_order}.json` must be provided to load
         waveform modes.
 
-        When `include_zero_ecc` or `include_params_dict` is True,
-        `metadata.txt` is required to obtain the parameters used in the NR
-        simulation. See more under `get_params_dict_from_sxs_metadata`.
+        When `include_zero_ecc` or `include_params_dict` or `remove_memory` is
+        True, `metadata.txt` or `metadata.json` is required to obtain the
+        parameters used in the NR simulation. See more under
+        `get_params_dict_from_sxs_metadata`.
 
         If `Horizons.h5` is provided, it is used to get a better estimate of
         the duration of an orbit from phase data to use it for removing junk
@@ -789,10 +789,11 @@ def load_sxs_catalogformat(**kwargs):
         for the same set of parameters except with eccentricity set to
         zero.
 
-        When set to True, the function will search for the `metadata.txt` file
-        in the `data_dir` directory. Typically, the `metadata.txt` file is
-        located in the same directory as the waveform file within the sxs
-        catalog. The `metadata.txt` file is essential for extracting binary
+        When set to True, the function will search for the `metadata.txt` or
+        `metadata.json` file in the `data_dir` directory. Typically, the
+        `metadata.txt` or `metadata.json` file is located in the same directory
+        as the waveform file within the sxs catalog. The
+        `metadata.txt`/`metadata.json` file is essential for extracting binary
         parameters and related metadata, as it typically contains crucial
         information about the binary parameters and the NR simulation used to
         generate the waveform modes.
@@ -916,9 +917,9 @@ def load_sxs_catalogformat_old(**kwargs):
     following files are looked for in the `data_dir` directory:
 
     1. `rhOverM_Asymptotic_GeometricUnits_CoM.h5` (mandatory).
-    2. `metadata.txt` (required when `include_zero_ecc`
-          or `include_params_dict` is True). For more details, see `data_dir`
-      under `load_sxs_catalogformat`.
+    2. `metadata.txt` or `metadata.json` (required when `include_zero_ecc` or
+        `include_params_dict` or `remove_memory` is True). For more details,
+        see `data_dir` under `load_sxs_catalogformat`.
     3. `Horizons.h5` (optional). For more details, see `data_dir`
       under `load_sxs_catalogformat`.
     """
@@ -960,9 +961,9 @@ def check_sxs_data_dir(origin, **kwargs):
          - `rhOverM_Asymptotic_GeometricUnits_CoM.h5`.
 
         These files are required to extract the waveform modes successfully.
-    - `metadata.txt` file to get the parameters of the NR Simulation.
-        This file is required when `include_zero_ecc` or `include_params_dict`
-        is True.
+    - `metadata.txt` or `metadata.json` file to get the parameters of the NR
+        Simulation.  This file is required when `include_zero_ecc` or
+        `include_params_dict` or `remove_memory` is True.
     - `Horizons.h5` file to estimate the duration of an orbit using the orbital
         phase data. This file is optional. If it is not found, we use the phase
         of the (2, 2) mode to get the duration of an orbit assuming a phase
@@ -1015,7 +1016,8 @@ def check_sxs_data_dir(origin, **kwargs):
         if not os.path.exists(
                 os.path.join(kwargs["data_dir"], filename)):
             if filename == "metadata.txt":
-                # check if metadata.json exists
+                # In newer versions of sxs catalog, metadata.txt is replace by metadata.json.
+                # If metadata.txt is not found, we check if metadata.json exists
                 if os.path.exists(
                         os.path.join(kwargs["data_dir"], 'metadata.json')):
                     continue

--- a/gw_eccentricity/load_data.py
+++ b/gw_eccentricity/load_data.py
@@ -1131,6 +1131,9 @@ def get_modes_dict_from_sxs_catalog_old_format(**kwargs):
             time = mode_data[:, 0]
             t = np.arange(time[0], time[-1], kwargs["deltaTOverM"])
         hlm = mode_data[:, 1] + 1j * mode_data[:, 2]
+        # See comments under `get_modes_dict_from_sxs_catalog_format` on why we
+        # interpolate real and imaginary parts instead of the amplitude and
+        # phase.
         real_interp = interpolate(t, time, np.real(hlm))
         imag_interp = interpolate(t, time, np.imag(hlm))
         hlm_interp = real_interp + 1j * imag_interp
@@ -1179,6 +1182,14 @@ def get_modes_dict_from_sxs_catalog_format(**kwargs):
     for mode in kwargs["mode_array"]:
         ell, m = mode
         hlm = waveform_modes[:, waveform.index(ell, m)]
+        # NOTE: We interpolate the real and imaginary parts of the modes,
+        # instead of interpolating the amplitude and phase. We noticed that for
+        # systems with high eccentricity and extreme precession, interpolating
+        # amplitude and phase over smaller deltaTOverM values introduces
+        # artificial spikes in the frequency that are absent in the original
+        # data. These spikes become more pronounced as the spline order
+        # increases. In contrast, interpolating the real and imaginary parts
+        # avoids these issues.
         real_interp = interpolate(t, time, np.real(hlm))
         imag_interp = interpolate(t, time, np.imag(hlm))
         hlm_interp = real_interp + 1j * imag_interp

--- a/gw_eccentricity/load_data.py
+++ b/gw_eccentricity/load_data.py
@@ -1091,6 +1091,8 @@ def make_return_dict_for_sxs_catalog_format(t, modes_dict, horizon_file_exits,
     # if include_zero_ecc is True, load zeroecc dataDict
     if kwargs["include_zero_ecc"]:
         params_dict_zero_ecc = params_dict.copy()
+        # remove t_relax from the params dict
+        params_dict_zero_ecc.pop("t_relax", None)
         # provide the approximant to be used for zero eccentricity waveform
         params_dict_zero_ecc.update(
             {"approximant": kwargs["zero_ecc_approximant"],

--- a/gw_eccentricity/plot_settings.py
+++ b/gw_eccentricity/plot_settings.py
@@ -205,5 +205,7 @@ labelsDict = {
     "res_omega_gw_dimless": r"$\Delta\omega_{\mathrm{gw}}$ [rad/$M$]",
     "res_amp_gw": r"$\Delta A_{\mathrm{gw}}$",
     "omega22_copr_symm": r"$\omega_{22}^{\mathrm{copr, sym}}$",
-    "amp22_copr_symm": r"$A_{22}^{\mathrm{copr, sym}}$" 
+    "amp22_copr_symm": r"$A_{22}^{\mathrm{copr, sym}}$",
+    "res_omega22_copr_symm": r"$\Delta \omega_{22}^{\mathrm{copr, sym}}$",
+    "res_amp22_copr_symm": r"$\Delta A_{22}^{\mathrm{copr, sym}}$" 
 }


### PR DESCRIPTION
Removing memory may give better results for high mass-ration, and eccentric precessing systems. This PR adds an option for `sxs` waveforms.