### PR TITLE
add option for frame to rotate modes internally if required

### DIFF
--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -169,7 +169,10 @@ class eccDefinition:
                   directly via `dataDict`.
                 - Set `frame="inertial"` and provide the inertial frame modes
                   via `dataDict`. In this case, the modes in `dataDict` are
-                  rotated internally before further computation.
+                  rotated internally (see `rotate_modes`) before further
+                  computation. To get the coprecessing modes from the inertial
+                  modes accurately, `dataDict` must include all modes for
+                  `ell=2`, i.e., (2, -2), (2, -1), (2, 0), (2, 1) and (2, 2).
 
             For nonprecessing systems, the inertial and coprecessing frames are
             equivalent, so there is no distinction.

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -175,23 +175,22 @@ class eccDefinition:
                   `ell=2`, i.e., (2, -2), (2, -1), (2, 0), (2, 1) and (2, 2).
 
             For nonprecessing systems, the inertial and coprecessing frames are
-            equivalent, so there is no distinction.
+            equivalent, so there is no distinction. For nonprecessing systems,
+            it is sufficient to include only the (2, 2) mode.
 
             Default is `False`, indicating the system is nonprecessing.
 
         frame: str, default="inertial"
             Specifies the reference frame for the modes in `dataDict`.
-            Acceptable values are:
-                - "inertial": The modes in `dataDict` are in the inertial
-                  frame.
-                - "coprecessing": The modes in `dataDict` are in the
-                  coprecessing frame.
+            
+            This parameter determines the frame in which the mode data is
+            provided. It is especially relevant for measuring eccentricity in
+            precessing systems, as the choice of reference frame affects the
+            interpretation of the modes. Use this in conjunction with the
+            `precessing` parameter (see its documentation for more details) to
+            ensure appropriate handling of the data.
 
-            If the system is precessing (`precessing=True`) and
-            `frame="inertial"`, the modes in `dataDict` are rotated into the
-            coprecessing frame for further computation. If
-            `frame="coprecessing"` with a precessing system, the modes in
-            `dataDict` are expected to be already in the coprecessing frame.
+            Currently `frame` can be "inertial" or "coprecessing".
 
             Default value is "inertial".
 
@@ -308,10 +307,10 @@ class eccDefinition:
         self.precessing = precessing
         self.frame = frame
         # check if frame makes sense.
-        self.available_frames = ["inertial", "coprecessing"]
-        if self.frame not in self.available_frames:
+        available_frames = ["inertial", "coprecessing"]
+        if self.frame not in available_frames:
             raise ValueError(f"Unknown frame `{self.frame}`. Frame should be "
-                             f"one of {self.available_frames}")
+                             f"one of {available_frames}")
 
         # Get data necessary for eccentricity measurement
         self.dataDict, self.t_merger, self.amp_gw_merger, \

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -8,6 +8,8 @@ https://github.com/vijayvarma392/gw_eccentricity/wiki/Adding-new-eccentricity-de
 
 import numpy as np
 import matplotlib.pyplot as plt
+from copy import deepcopy
+from .load_data import get_coprecessing_data_dict
 from .utils import peak_time_via_quadratic_fit, check_kwargs_and_set_defaults
 from .utils import amplitude_using_all_modes
 from .utils import time_deriv_4thOrder
@@ -24,6 +26,7 @@ class eccDefinition:
 
     def __init__(self, dataDict, num_orbits_to_exclude_before_merger=2,
                  precessing=False,
+                 frame="inertial",
                  extra_kwargs=None):
         """Init eccDefinition class.
 
@@ -163,6 +166,28 @@ class eccDefinition:
 
             Default is False which implies the system to be nonprecessing.
 
+        frame: str, default="inertial"
+            Specifies the reference frame for the modes in `dataDict`. Acceptable values are:
+            - "inertial": The modes in `dataDict` are in the inertial frame.
+            - "coprecessing": The modes in `dataDict` are in the coprecessing frame.
+
+            If the system is precessing (`precessing=True`) and `frame="inertial"`, the modes in
+            `dataDict` are rotated into the coprecessing frame for further computation. If
+            `frame="coprecessing"` with a precessing system, the modes in `dataDict` are expected
+            to be already in the coprecessing frame.
+
+            For nonprecessing systems only (2, 2) mode is sufficient for measuring eccentricity.
+            For precessing system, we use both (2, 2) and (2, -2) mode data in the coprecessing
+            frame. Therefore, if the system is nonprecessing (`precessing=False`) but 
+            `frame="coprecessing"`, an exception is raised to avoid ambiguity because for nonprecessing systems,
+            inertial and coprecessing frames are equivalent and (2, -2) mode is not required.
+
+            TODO: Should we make all m modes for l=2 mandatory for getting coprecessing modes? It seems,
+            any missing m modes causes oscillations in egw.
+
+            Default value is "inertial".
+
+
         extra_kwargs: dict
             A dictionary of any extra kwargs to be passed. Allowed kwargs
             are:
@@ -274,6 +299,17 @@ class eccDefinition:
                 USE THIS WITH CAUTION!
         """
         self.precessing = precessing
+        self.frame = frame
+        # check if frame makes sense. If system is nonprecessing, frame should be inertial
+        self.available_frames = ["inertial", "coprecessing"]
+        if self.frame not in self.available_frames:
+            raise ValueError(f"Unknown frame `{self.frame}`. Frame should be one of  "
+                             f"{self.available_frames}")
+        if not self.precessing and self.frame != "inertial":
+            raise Exception("The system is nonprecessing since `precessing` is set to "
+                            f"{self.precessing} but the frame is set to {self.frame}. When the "
+                            "system is nonprecessing, frame should be 'inertial'.")
+
         # Get data necessary for eccentricity measurement
         self.dataDict, self.t_merger, self.amp_gw_merger, \
             min_width_for_extrema = self.process_data_dict(
@@ -579,6 +615,9 @@ class eccDefinition:
                 "1. 'hlm' OR \n"
                 "2. 'amplm' and 'phaselm'\n"
                 "But not both 1. and 2. at the same time."))
+        # if the system is precessing, rotate the modes in dataDict to coprecessing frame
+        if self.precessing is True and self.frame == "inertial":
+            dataDict = self.rotate_modes(dataDict)
         # Create a new dictionary that will contain the data necessary for
         # eccentricity measurement.
         newDataDict = {}
@@ -657,6 +696,49 @@ class eccDefinition:
                     newDataDict["t"] = newDataDict["t"][
                         :index_num_orbits_earlier_than_merger]
         return newDataDict, t_merger, amp_gw_merger, min_width_for_extrema
+    
+    def rotate_modes(self, data_dict):
+        """"Rotate intertial modes in data_dict to coprecessing frame."""
+        if "hlm" in data_dict:
+            data_dict = get_coprecessing_data_dict(data_dict)
+        if "hlm_zeroecc" in data_dict:
+            intertial_zeroecc_data_dict = {"t": data_dict["t_zeroecc"],
+                                           "hlm": data_dict["hlm_zeroecc"]}
+            coprecessing_zeroecc_data_dict = get_coprecessing_data_dict(intertial_zeroecc_data_dict)
+            data_dict.update({"hlm_zeroecc": coprecessing_zeroecc_data_dict["hlm"]})
+        # if hlm is not in data_dict, get it from amplm and phaselm.
+        # We need to provide hlm to get the rotated modes.
+        if "hlm" not in data_dict:
+            amplm_dict = self.get_amplm_from_dataDict(data_dict)
+            phaselm_dict = self.get_phaselm_from_dataDict(data_dict)
+            hlm_dict = {}
+            # check if "hlm_zeroecc" is not in data_dict but amplm_zeroecc is in data_dict
+            if "amplm_zeroecc" in data_dict and "hlm_zeroecc" not in data_dict:
+                add_hlm_zeroecc = True
+                hlm_zeroecc_dict = {}
+            else:
+                add_hlm_zeroecc = False
+            # combine amplm and phaselm to get hlm
+            for k in amplm_dict["amplm"]:
+                hlm_dict.update({k: amplm_dict["amplm"][k] * np.exp(-1j * phaselm_dict["phaselm"][k])})
+                if add_hlm_zeroecc:
+                    hlm_zeroecc_dict.update({k: amplm_dict["amplm_zeroecc"][k] * np.exp(-1j * phaselm_dict["phaselm_zeroecc"][k])})
+            inertial_ecc_data_dict = {"t": data_dict["t"], "hlm": hlm_dict}
+            coprecessing_ecc_data_dict = get_coprecessing_data_dict(inertial_ecc_data_dict)
+            data_dict.update(coprecessing_ecc_data_dict)
+            # remove amplm, phaselm because these are in the inertial frame
+            # and are given priority when using data for egw over hlm
+            data_dict.pop("amplm", None)
+            data_dict.pop("phaselm", None)
+            if add_hlm_zeroecc:
+                inertial_zeroecc_data_dict = {"t": data_dict["t_zeroecc"], "hlm": hlm_zeroecc_dict}
+                coprecessing_zeroecc_data_dict = get_coprecessing_data_dict(inertial_zeroecc_data_dict)
+                data_dict.update({"hlm_zeroecc": coprecessing_zeroecc_data_dict["hlm"]})
+                # remove amplm_zeroecc, phaselm_zeroecc because these are in the inertial frame
+                # and are given priority when using data for egw over hlm_zeroecc
+                data_dict.pop("amplm_zeroecc", None)
+                data_dict.pop("phaselm_zeroecc", None)
+        return data_dict
 
     def get_amp_phase_omega_gw(self, data_dict):
         """Get the gw quanitities from modes dict in the coprecessing frame.

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -8,6 +8,7 @@ https://github.com/vijayvarma392/gw_eccentricity/wiki/Adding-new-eccentricity-de
 
 import numpy as np
 import matplotlib.pyplot as plt
+import warnings
 from .load_data import get_coprecessing_data_dict
 from .utils import peak_time_via_quadratic_fit, check_kwargs_and_set_defaults
 from .utils import amplitude_using_all_modes
@@ -622,23 +623,16 @@ class eccDefinition:
         # frame, rotate the modes and obtain the corresponding modes in the
         # coprecessing frame
         if self.precessing is True and self.frame == "inertial":
-            # get debug level
-            if extra_kwargs is not None:
-                debug_level = extra_kwargs.get("debug_level", 0)
-            else:
-                debug_level = 0
-            debug_message(
+            warnings.warn(
                 f"The system is precessing but the modes are provided in "
                 f"the {self.frame} frame. Transforming the modes from"
                 f" the {self.frame} frame to the coprecessing frame and "
-                "updating `self.frame` to `coprecessing`.",
-                debug_level=debug_level, important=False)
-            dataDict = self.transform_inertial_to_coprecessing(
-                dataDict, debug_level=debug_level)
+                "updating `self.frame` to `coprecessing`.")
+            dataDict = self.transform_inertial_to_coprecessing(dataDict)
             # transform the zeroecc modes as well if provided in dataDict
             if "hlm_zeroecc" in dataDict or "amplm_zeroecc" in dataDict:
                 dataDict = self.transform_inertial_to_coprecessing(
-                    dataDict, tag="_zeroecc", debug_level=debug_level)
+                    dataDict, tag="_zeroecc")
             # Now that the modes are in the coprecessing frame, update frame
             self.frame = "coprecessing"
         # Create a new dictionary that will contain the data necessary for
@@ -720,8 +714,7 @@ class eccDefinition:
                 :index_num_orbits_earlier_than_merger]
         return newDataDict, t_merger, amp_gw_merger, min_width_for_extrema
 
-    def transform_inertial_to_coprecessing(
-            self, data_dict, tag="", debug_level=0):
+    def transform_inertial_to_coprecessing(self, data_dict, tag=""):
         """"Transfrom intertial frame modes to coprecessing frame modes.
         
         Parameters
@@ -746,10 +739,6 @@ class eccDefinition:
             as the default value (`""`), the inertial frame modes for the
             eccentric case are used.
 
-        debug_level: int, default=0
-            Debug level to use. See documentation for `debug_level` under
-            `extra_kwargs`
-
         Returns
         -------
         data_dict with the inertial modes replaced by the corresponding
@@ -766,22 +755,20 @@ class eccDefinition:
             hlm_dict = self.get_hlm_from_amplm_phaselm(amplm_dict, phaselm_dict)
             data_dict.update(hlm_dict)
             data_dict = get_coprecessing_data_dict(data_dict, tag=tag)
-            debug_message(
+            warnings.warn(
                 f"Removing the input inertial frame {'amplm' + tag}, "
                 f"{'phaselm' + tag} from `dataDict`. The corresponding "
                 "coprecessing frame quantities are computed "
                 f"later from the coprecessing {'hlm' + tag} in "
-                f"`get_amp_phase_omega_data`.", debug_level=debug_level,
-                important=False)
+                f"`get_amp_phase_omega_data`.")
             data_dict.pop("amplm" + tag, None)
             data_dict.pop("phaselm" + tag, None)
         if "omegalm" + tag in data_dict:
-            debug_message(
+            warnings.warn(
                 f"Removing the input inertial frame {'omegalm' + tag} "
                 f"from `dataDict`. The coprecessing {'omegalm' + tag} is "
                 f"computed later from the coprecessing {'hlm' + tag} in "
-                f"`get_amp_phase_omega_data`.", debug_level=debug_level,
-                important=False)
+                f"`get_amp_phase_omega_data`.")
             data_dict.pop("omegalm" + tag, None)
         return data_dict
     

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -732,12 +732,12 @@ class eccDefinition:
             coprecessing frame modes.
 
         suffix: str, default=""
-            A suffix used to specify which input modes dictionary to use for
-            obtaining the coprecessing modes. For example, using
-            `suffix="_zeroecc"` selects the input modes corresponding to the
-            "zeroecc" modes dictionary, which are then rotated to compute the
-            coprecessing modes. If left as the default value (`""`), the input
-            modes from the eccentric modes dictionary are used.
+            A suffix specifying which inertial frame data to use when
+            transforming inertial frame modes to coprecessing frame modes. For
+            example, setting `suffix="_zeroecc"` selects the inertial frame
+            modes corresponding to the "zeroecc" (non-eccentric) case. If left
+            as the default value (`""`), the inertial frame modes for the
+            eccentric case are used.
 
         Returns
         -------
@@ -756,17 +756,18 @@ class eccDefinition:
             data_dict.update(hlm_dict)
             data_dict = get_coprecessing_data_dict(data_dict, suffix=suffix)
             warnings.warn(
-                f"Removing the inertial {'amplm' + suffix}, "
-                f"{'phaselm' + suffix} from `dataDict`. The same is computed "
+                f"Removing the input inertial frame {'amplm' + suffix}, "
+                f"{'phaselm' + suffix} from `dataDict`. The corresponding "
+                "coprecessing frame quantities are computed "
                 f"later from the coprecessing {'hlm' + suffix} in"
-                f"`get_amp_phase_omega_data.`")
+                f"`get_amp_phase_omega_data`.")
             data_dict.pop("amplm" + suffix, None)
             data_dict.pop("phaselm" + suffix, None)
         if "omegalm" + suffix in data_dict:
             warnings.warn(
-                f"Removing the inertial {'omegalm' + suffix} from `dataDict`. "
-                f"The coprecessing {'omegalm' + suffix}. The same is computed "
-                f"later from the coprecessing {'hlm' + suffix} in "
+                f"Removing the input inertial frame {'omegalm' + suffix} "
+                f"from `dataDict`. The coprecessing {'omegalm' + suffix} is "
+                f"computed later from the coprecessing {'hlm' + suffix} in "
                 f"`get_amp_phase_omega_data`.")
             data_dict.pop("omegalm" + suffix, None)
         return data_dict

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -697,8 +697,8 @@ class eccDefinition:
                 for mode in newDataDict[k]:
                     newDataDict[k][mode] = newDataDict[k][mode][
                         :index_num_orbits_earlier_than_merger]
-                    newDataDict["t"] = newDataDict["t"][
-                        :index_num_orbits_earlier_than_merger]
+            newDataDict["t"] = newDataDict["t"][
+                :index_num_orbits_earlier_than_merger]
         return newDataDict, t_merger, amp_gw_merger, min_width_for_extrema
 
     def rotate_modes(self, data_dict):

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -632,7 +632,7 @@ class eccDefinition:
             # transform the zeroecc modes as well if provided in dataDict
             if "hlm_zeroecc" in dataDict or "amplm_zeroecc" in dataDict:
                 dataDict = self.transform_inertial_to_coprecessing(
-                    dataDict, suffix="_zeroecc")
+                    dataDict, tag="_zeroecc")
             # Now that the modes are in the coprecessing frame, update frame
             self.frame = "coprecessing"
         # Create a new dictionary that will contain the data necessary for
@@ -759,7 +759,7 @@ class eccDefinition:
                 f"Removing the input inertial frame {'amplm' + tag}, "
                 f"{'phaselm' + tag} from `dataDict`. The corresponding "
                 "coprecessing frame quantities are computed "
-                f"later from the coprecessing {'hlm' + tag} in"
+                f"later from the coprecessing {'hlm' + tag} in "
                 f"`get_amp_phase_omega_data`.")
             data_dict.pop("amplm" + tag, None)
             data_dict.pop("phaselm" + tag, None)

--- a/gw_eccentricity/eccDefinition.py
+++ b/gw_eccentricity/eccDefinition.py
@@ -619,7 +619,8 @@ class eccDefinition:
                 "1. 'hlm' OR \n"
                 "2. 'amplm' and 'phaselm'\n"
                 "But not both 1. and 2. at the same time."))
-        # if the system is precessing, rotate the modes in dataDict to
+        # if the system is precessing and the modes are given in the inertial
+        # frame, rotate the modes and the corresponding modes in the
         # coprecessing frame
         if self.precessing is True and self.frame == "inertial":
             dataDict = self.rotate_modes(dataDict)

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -311,10 +311,11 @@ def measure_eccentricity(tref_in=None,
                 directly via `dataDict`.
             - Set `frame="inertial"` and provide the inertial frame modes
                 via `dataDict`. In this case, the modes in `dataDict` are
-                rotated internally (see `rotate_modes`) before further
-                computation. To get the coprecessing modes from the inertial
-                modes accurately, `dataDict` must include all modes for
-                `ell=2`, i.e., (2, -2), (2, -1), (2, 0), (2, 1) and (2, 2).
+                rotated internally (see `transform_inertial_to_coprecessing`)
+                before further computation. To get the coprecessing modes from
+                the inertial modes accurately, `dataDict` must include all
+                modes for `ell=2`, i.e., (2, -2), (2, -1), (2, 0), (2, 1) and
+                (2, 2).
 
         For nonprecessing systems, the inertial and coprecessing frames are
         equivalent, so there is no distinction. For nonprecessing systems, it

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -322,18 +322,16 @@ def measure_eccentricity(tref_in=None,
         Default is `False`, indicating the system is nonprecessing.
 
     frame: str, default="inertial"
-        Specifies the reference frame for the modes in `dataDict`. Acceptable
-        values are:
-            - "inertial": The modes in `dataDict` are in the inertial
-                frame.
-            - "coprecessing": The modes in `dataDict` are in the
-                coprecessing frame.
+        Specifies the reference frame for the modes in `dataDict`.
+            
+        This parameter determines the frame in which the mode data is provided.
+        It is especially relevant for measuring eccentricity in precessing
+        systems, as the choice of reference frame affects the interpretation of
+        the modes. Use this in conjunction with the `precessing` parameter (see
+        its documentation for more details) to ensure appropriate handling of
+        the data.
 
-        If the system is precessing (`precessing=True`) and `frame="inertial"`,
-        the modes in `dataDict` are rotated into the coprecessing frame for
-        further computation. If `frame="coprecessing"` with a precessing
-        system, the modes in `dataDict` are expected to be already in the
-        coprecessing frame.
+        Currently `frame` can be "inertial" or "coprecessing".
 
         Default value is "inertial".
 

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -317,7 +317,8 @@ def measure_eccentricity(tref_in=None,
                 `ell=2`, i.e., (2, -2), (2, -1), (2, 0), (2, 1) and (2, 2).
 
         For nonprecessing systems, the inertial and coprecessing frames are
-        equivalent, so there is no distinction.
+        equivalent, so there is no distinction. For nonprecessing systems, it
+        is sufficient to include only the (2, 2) mode.
 
         Default is `False`, indicating the system is nonprecessing.
 

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -311,7 +311,10 @@ def measure_eccentricity(tref_in=None,
                 directly via `dataDict`.
             - Set `frame="inertial"` and provide the inertial frame modes
                 via `dataDict`. In this case, the modes in `dataDict` are
-                rotated internally before further computation.
+                rotated internally (see `rotate_modes`) before further
+                computation. To get the coprecessing modes from the inertial
+                modes accurately, `dataDict` must include all modes for
+                `ell=2`, i.e., (2, -2), (2, -1), (2, 0), (2, 1) and (2, 2).
 
         For nonprecessing systems, the inertial and coprecessing frames are
         equivalent, so there is no distinction.

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -64,6 +64,7 @@ def measure_eccentricity(tref_in=None,
                          dataDict=None,
                          num_orbits_to_exclude_before_merger=2,
                          precessing=False,
+                         frame="inertial",
                          extra_kwargs=None):
     """Measure eccentricity and mean anomaly from a gravitational waveform.
 
@@ -469,7 +470,7 @@ def measure_eccentricity(tref_in=None,
     if method in available_methods:
         gwecc_object = available_methods[method](
             dataDict, num_orbits_to_exclude_before_merger,
-            precessing, extra_kwargs)
+            precessing, frame, extra_kwargs)
         return_dict = gwecc_object.measure_ecc(
             tref_in=tref_in, fref_in=fref_in)
         return_dict.update({"gwecc_object": gwecc_object})

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -300,12 +300,39 @@ def measure_eccentricity(tref_in=None,
         Default: 2.
 
     precessing: bool, default=False
-        Whether the system is precessing or not. For precessing systems, the
-        `dataDict` should contain modes in the coprecessing frame. For
-        nonprecessing systems, there is no distiction between the inertial and
-        coprecessing frame since they are the same.
+        Indicates whether the system is precessing. For precessing systems, the
+        (2, 2) and (2, -2) modes in the coprecessing frame are required to
+        compute `amp_gw`, `phase_gw`, and `omega_gw` (see
+        `get_amp_phase_omega_gw`), which are used to determine eccentricity.
 
-        Default is False which implies the system to be nonprecessing.
+        For precessing systems, waveform modes in the coprecessing frame must
+        be provided. This can be done in two ways:
+            - Set `frame="coprecessing"` and supply the coprecessing modes
+                directly via `dataDict`.
+            - Set `frame="inertial"` and provide the inertial frame modes
+                via `dataDict`. In this case, the modes in `dataDict` are
+                rotated internally before further computation.
+
+        For nonprecessing systems, the inertial and coprecessing frames are
+        equivalent, so there is no distinction.
+
+        Default is `False`, indicating the system is nonprecessing.
+
+    frame: str, default="inertial"
+        Specifies the reference frame for the modes in `dataDict`. Acceptable
+        values are:
+            - "inertial": The modes in `dataDict` are in the inertial
+                frame.
+            - "coprecessing": The modes in `dataDict` are in the
+                coprecessing frame.
+
+        If the system is precessing (`precessing=True`) and `frame="inertial"`,
+        the modes in `dataDict` are rotated into the coprecessing frame for
+        further computation. If `frame="coprecessing"` with a precessing
+        system, the modes in `dataDict` are expected to be already in the
+        coprecessing frame.
+
+        Default value is "inertial".
 
     extra_kwargs: A dict of any extra kwargs to be passed. Allowed kwargs are:
         spline_kwargs:

--- a/gw_eccentricity/load_data.py
+++ b/gw_eccentricity/load_data.py
@@ -1500,13 +1500,15 @@ def package_modes_for_scri(modes_dict, ell_min, ell_max):
     for ell in range(ell_min, ell_max + 1):
         for m in range(-ell, ell + 1):            
             if (ell, m) in keys:
-                # for each m > 0, the m < 0 counterpart should also exist in the `data_dict`
-                if m > 0:
-                    if (ell, -m) not in keys:
-                        raise Exception("For each m > 0, corresponding m < 0 mode should also exist "
-                                        f"in the input `data_dict`. {(ell, m)} mode exists but "
-                                        f" {(ell, -m)} mode does not exist.")
                 result[:, i] = modes_dict[(ell, m)]
+            else:
+                # for a given ell, all (ell, m) modes should exist in the 
+                # modes_dict
+                raise Exception(
+                    f"{ell, m} mode for ell={ell} does not exist in the "
+                    "modes dict. To get the coprecessing modes accurately, "
+                    "all the `(ell, m)` modes for a given `ell` should exist "
+                    "in the input modes dict.")
             i += 1
     return result
 

--- a/gw_eccentricity/load_data.py
+++ b/gw_eccentricity/load_data.py
@@ -1534,7 +1534,7 @@ def unpack_scri_modes(w):
     return result
 
 
-def get_coprecessing_data_dict(data_dict, ell_min=2, ell_max=2, suffix=""):
+def get_coprecessing_data_dict(data_dict, ell_min=2, ell_max=2, tag=""):
     """Get `data_dict` in the coprecessing frame.
 
     Given a `data_dict` containing the modes dict in the inertial frame and the
@@ -1556,10 +1556,10 @@ def get_coprecessing_data_dict(data_dict, ell_min=2, ell_max=2, suffix=""):
     ell_max: int, default=2
         Maximum `ell` value to use.
 
-    suffix: str, default=""
-        A suffix specifying which inertial frame data to use when transforming
+    tag: str, default=""
+        A tag specifying which inertial frame data to use when transforming
         inertial frame modes to coprecessing frame modes. For example, setting
-        `suffix="_zeroecc"` selects the inertial frame modes corresponding to
+        `tag="_zeroecc"` selects the inertial frame modes corresponding to
         the "zeroecc" (non-eccentric) case. If left as the default value
         (`""`), the inertial frame modes for the eccentric case are used.
 
@@ -1571,13 +1571,13 @@ def get_coprecessing_data_dict(data_dict, ell_min=2, ell_max=2, suffix=""):
     """
     # Get list of modes from `data_dict` to use as input to `scri.WaveformModes`.
     ordered_mode_list = package_modes_for_scri(
-        data_dict["hlm" + suffix],
+        data_dict["hlm" + tag],
         ell_min=ell_min,
         ell_max=ell_max)
 
     w = scri.WaveformModes(
         dataType=scri.h,
-        t=data_dict["t" + suffix],
+        t=data_dict["t" + tag],
         data=ordered_mode_list,
         ell_min=ell_min,
         ell_max=ell_max,
@@ -1591,7 +1591,7 @@ def get_coprecessing_data_dict(data_dict, ell_min=2, ell_max=2, suffix=""):
     # with the corresponding modes in the coprecessing frame
     data_dict_copr = deepcopy(data_dict)
     data_dict_copr.update(
-        {"hlm" + suffix: unpack_scri_modes(deepcopy(w_coprecessing))})
+        {"hlm" + tag: unpack_scri_modes(deepcopy(w_coprecessing))})
     return data_dict_copr
 
 

--- a/gw_eccentricity/load_data.py
+++ b/gw_eccentricity/load_data.py
@@ -1534,7 +1534,7 @@ def unpack_scri_modes(w):
     return result
 
 
-def get_coprecessing_data_dict(data_dict, ell_min=2, ell_max=2):
+def get_coprecessing_data_dict(data_dict, ell_min=2, ell_max=2, suffix=""):
     """Get `data_dict` in the coprecessing frame.
 
     Given a `data_dict` containing the modes dict in the inertial frame and the
@@ -1556,6 +1556,14 @@ def get_coprecessing_data_dict(data_dict, ell_min=2, ell_max=2):
     ell_max: int, default=2
         Maximum `ell` value to use.
 
+    suffix: str, default=""
+        A suffix used to specify which input modes dictionary to use for
+        obtaining the coprecessing modes. For example, using
+        `suffix="_zeroecc"` selects the input modes corresponding to the
+        "zeroecc" modes dictionary, which are then rotated to compute the
+        coprecessing modes. If left as the default value (`""`), the input
+        modes from the eccentric modes dictionary are used.
+
     Returns
     -------
     Dictionary of waveform modes in the coprecessing frame and the associated
@@ -1564,13 +1572,13 @@ def get_coprecessing_data_dict(data_dict, ell_min=2, ell_max=2):
     """
     # Get list of modes from `data_dict` to use as input to `scri.WaveformModes`.
     ordered_mode_list = package_modes_for_scri(
-        data_dict["hlm"],
+        data_dict["hlm" + suffix],
         ell_min=ell_min,
         ell_max=ell_max)
 
     w = scri.WaveformModes(
         dataType=scri.h,
-        t=data_dict["t"],
+        t=data_dict["t" + suffix],
         data=ordered_mode_list,
         ell_min=ell_min,
         ell_max=ell_max,
@@ -1583,7 +1591,8 @@ def get_coprecessing_data_dict(data_dict, ell_min=2, ell_max=2):
     # Create a copy of data_dict and replace the "hlm" modes in the inertial frame
     # with the corresponding modes in the coprecessing frame
     data_dict_copr = deepcopy(data_dict)
-    data_dict_copr.update({"hlm": unpack_scri_modes(deepcopy(w_coprecessing))})
+    data_dict_copr.update(
+        {"hlm" + suffix: unpack_scri_modes(deepcopy(w_coprecessing))})
     return data_dict_copr
 
 

--- a/gw_eccentricity/load_data.py
+++ b/gw_eccentricity/load_data.py
@@ -1557,12 +1557,11 @@ def get_coprecessing_data_dict(data_dict, ell_min=2, ell_max=2, suffix=""):
         Maximum `ell` value to use.
 
     suffix: str, default=""
-        A suffix used to specify which input modes dictionary to use for
-        obtaining the coprecessing modes. For example, using
-        `suffix="_zeroecc"` selects the input modes corresponding to the
-        "zeroecc" modes dictionary, which are then rotated to compute the
-        coprecessing modes. If left as the default value (`""`), the input
-        modes from the eccentric modes dictionary are used.
+        A suffix specifying which inertial frame data to use when transforming
+        inertial frame modes to coprecessing frame modes. For example, setting
+        `suffix="_zeroecc"` selects the inertial frame modes corresponding to
+        the "zeroecc" (non-eccentric) case. If left as the default value
+        (`""`), the inertial frame modes for the eccentric case are used.
 
     Returns
     -------


### PR DESCRIPTION
Adds an argument `frame` which takes either of the two values `inertial` or `coprecessing`. If the system is `precessing` and `frame='inertial'`, the modes are rotated internally to get the dataDict in the coprecessing frame. This completes the extension of `gw_eccentricity` to precessing system.