### PR TITLE
upgrade to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ All of these can be installed through pip or conda.
 See example notebooks:
 * [gw_eccentricity demo](https://github.com/vijayvarma392/gw_eccentricity/blob/main/examples/gw_eccentricity_demo.ipynb) for how to use the package, along with diagnostic plots.
 * [Load waveforms demo](https://github.com/vijayvarma392/gw_eccentricity/blob/main/examples/load_waveform_demo.ipynb) for loading waveform data into a dictionary format suitable for gw_eccentricity, including for LAL, SXS, and LVCNR waveforms.
-  - [TEOBResumS demo](https://github.com/vijayvarma392/gw_eccentricity/blob/main/examples/egw_from_TEOBResumS-DALI_demo.ipynb) for the same for TEOBResumS.
+  - [TEOBResumS-Dali demo](https://github.com/vijayvarma392/gw_eccentricity/blob/main/examples/egw_from_TEOBResumS-DALI_demo.ipynb) for the same for `TEOBResumS-Dali`.
+  - [SEOBNRv5EHM demo](https://github.com/vijayvarma392/gw_eccentricity/blob/main/examples/egw_from_SEOBNRv5EHM_demo.ipynb) for the same for `SEOBNRv5EHM`.
 
 # Making contributions
 See this

--- a/gw_eccentricity/gw_eccentricity.py
+++ b/gw_eccentricity/gw_eccentricity.py
@@ -8,7 +8,7 @@ __copyright__ = "Copyright (C) 2023 Md Arif Shaikh, Vijay Varma, Harald Pfeiffer
 __email__ = "arifshaikh.astro@gmail.com, vijay.varma392@gmail.com"
 __status__ = "testing"
 __author__ = "Md Arif Shaikh, Vijay Varma, Harald Pfeiffer"
-__version__ = "1.0.4"
+__version__ = "2.0.0"
 __license__ = """
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Pypi package updated to `v2.0.0`

Major changes from the previous version
- Support for spin-precessing systems
- Rational Fits for building interpolants through the omega_gw extrema